### PR TITLE
Skip writing markers if event array is empty

### DIFF
--- a/pybv/io.py
+++ b/pybv/io.py
@@ -110,7 +110,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events):
         print(r'; Commas in type or description text are coded as "\1".', file=fout)  # noqa: E501
         print(r'Mk1=New Segment,,1,1,0,0', file=fout)
 
-        if events is None:
+        if events is None or len(events) == 0:
             return
 
         # Handle events


### PR DESCRIPTION
`np.log10(np.max(events[:, 1]))` fails if `events` is empty but not None, so writing the (non-existing) events should be skipped.