### PR TITLE
Support channel-specific scaling factors

### DIFF
--- a/pybv/io.py
+++ b/pybv/io.py
@@ -160,7 +160,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events):
 
 
 def _optimize_channel_unit(resolution):
-    """Calculate an optimal channel scaling factor and unit"""
+    """Calculate an optimal channel scaling factor and unit."""
     exp = np.log10(resolution)
     if exp <= -8:
         return resolution / 1e-9, 'nV'

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -170,12 +170,12 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
 
         print(r'[Channel Infos]', file=fout)
         print(r'; Each entry: Ch<Channel number>=<Name>,<Reference channel name>,', file=fout)  # noqa: E501
-        print(r';             <Resolution in microvolts>,<Future extensions..', file=fout)  # noqa: E501
+        print(r';             <Resolution in "unit">,<"unit">,<Future extensions..', file=fout)  # noqa: E501
         print(r'; Fields are delimited by commas, some fields might be omitted (empty).', file=fout)  # noqa: E501
         print(r'; Commas in channel names are coded as "\1".', file=fout)
         resolution_in_microv = resolution / 1e-6
         for ii, ch in enumerate(ch_names, start=1):
-            print(r'Ch{}={},,{:0.1f}'
+            print(r'Ch{}={},,{:0.1f},μV'
                   .format(ii, ch, resolution_in_microv), file=fout)
 
         print(r'', file=fout)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -208,7 +208,7 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
 
         print(r'[Channel Infos]', file=fout)
         print(r'; Each entry: Ch<Channel number>=<Name>,<Reference channel name>,', file=fout)  # noqa: E501
-        print(r';             <Resolution in "unit">,<"unit">,<Future extensions..', file=fout)  # noqa: E501
+        print(r'; <Resolution in "unit">,<unit>,Future extensions…', file=fout)
         print(r'; Fields are delimited by commas, some fields might be omitted (empty).', file=fout)  # noqa: E501
         print(r'; Commas in channel names are coded as "\1".', file=fout)
 

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -118,8 +118,7 @@ def _chk_fmt(fmt):
 
 
 def _chk_multiplexed(orientation):
-    """Check if the passed orientation is supported and return if
-    it is multiplexed (True) or vectorized (False)"""
+    """Validate an orientation, return if it is multiplexed or not."""
     orientation = orientation.lower()
     if orientation not in supported_orients:
         errmsg = ('Orientation {} not supported.'.format(orientation) +

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -24,7 +24,7 @@ supported_orients = {'multiplexed'}
 
 
 def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
-                      events=None, resolution=1e-7):
+                      events=None, resolution=1e-7, scale_data=True):
     """Write raw data to BrainVision format.
 
     Parameters
@@ -52,6 +52,11 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
         in microvolts, the data will be multiplied by the inverse of this
         factor, and all decimals will be cut off after this. So, this number
         controls the amount of round-trip resolution you want.
+    scale_data : bool
+        Boolean indicating if the data is in volts and should be scaled to
+        `resolution` (True), or if the data is already in the previously
+        specified target resolution and should be left as-is (False).
+        This is mostly useful if you have int16 data with a custom resolution.
     """
     # Create output file names/paths
     if not op.isdir(folder_out):
@@ -90,7 +95,7 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
     _write_vmrk_file(vmrk_fname, eeg_fname, events)
     _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq,
                      ch_names, resolution=resolution)
-    _write_bveeg_file(eeg_fname, data, resolution=resolution)
+    _write_bveeg_file(eeg_fname, data, resolution=resolution, scale_data=True)
 
 
 def _chk_fmt(fmt):
@@ -197,7 +202,8 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
 
 
 def _write_bveeg_file(eeg_fname, data, orientation='multiplexed',
-                      format='binary_float32', resolution=1e-7):
+                      format='binary_float32', resolution=1e-7,
+                      scale_data=True):
     """Write BrainVision data file."""
     fmt = format.lower()
 
@@ -210,5 +216,6 @@ def _write_bveeg_file(eeg_fname, data, orientation='multiplexed',
 
     # Invert the resolution so that we know how much to scale our data
     scaling_factor = 1 / resolution
-    data = data * scaling_factor
+    if scale_data:
+        data = data * scaling_factor
     data.astype(dtype=dtype).ravel(order='F').tofile(eeg_fname)

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -80,7 +80,8 @@ def test_bv_writer_oi_cycle():
     tmpdir = _mktmpdir()
 
     # Write, then read the data to BV format
-    write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=events)
+    write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=events,
+                      resolution=np.power(10., -np.arange(10)))
     annot = mne.read_annotations(op.join(tmpdir, fname + '.vmrk'))
     raw_written = mne.io.read_raw_brainvision(op.join(tmpdir, fname + '.vhdr'),
                                               preload=True, stim_channel=False)
@@ -104,4 +105,14 @@ def test_bv_writer_oi_cycle():
     # channels
     assert ch_names == raw_written.ch_names
 
+    rmtree(tmpdir)
+
+
+def test_scale_data():
+    """Test that scale_data=False keeps the data untouched"""
+
+    tmpdir = _mktmpdir()
+    write_brainvision(data, sfreq, ch_names, fname, tmpdir, scale_data=False)
+    data_written = np.fromfile(tmpdir + '/' + fname + '.eeg', dtype=np.float32)
+    assert_allclose(data_written, data.T.flatten())
     rmtree(tmpdir)

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -109,8 +109,7 @@ def test_bv_writer_oi_cycle():
 
 
 def test_scale_data():
-    """Test that scale_data=False keeps the data untouched"""
-
+    """Test that scale_data=False keeps the data untouched."""
     tmpdir = _mktmpdir()
     write_brainvision(data, sfreq, ch_names, fname, tmpdir, scale_data=False)
     data_written = np.fromfile(tmpdir + '/' + fname + '.eeg', dtype=np.float32)


### PR DESCRIPTION
closes #12

This changes the resolution parameter to accept either a single parameter or an 1xnchan array for channel specific resolutions, adds a `scale_data` parameter (defaults to True) indicating whether the data needs to be scaled or is already scaled correctly and improves the scaling factor precision by allowing other units (`V` and `nV` for now).

To test it, I created a sample file with `write_brainvision(np.ones((4,12), 5, ['Foo','Bar','Baz','Fob'], 'test', '/tmp', events=None, resolution=[1e-8, 1e-5, .1, 2.5e-7], True)`, read it in with mne-python and confirmed the data array was all ones again, even though the channel resolutions were different.