### PR TITLE
Support writing custom event durations

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,7 @@ Current
 Changelog
 ~~~~~~~~~
 - Add option to disable writing a meas_date event (which is also the new default) by `Clemens Brunner`_ (`#32 <https://github.com/bids-standard/pybv/pull/32>`_)
-
+- Support event durations by passing an (N, 3) array to the events parameter (the third column contains the event durations) by `Clemens Brunner`_ (`#33 <https://github.com/bids-standard/pybv/pull/33>`_)
 
 
 0.1.0

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -183,7 +183,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
             return
 
         if events.shape[1] == 2:  # add third column with event durations of 1
-            events = np.column_stack([events, np.ones(len(events))])
+            events = np.column_stack([events, np.ones(len(events), dtype=int)])
 
         # Handle events: We write all of them as "Stimulus" events for now.
         # This is a string staring with "S" and followed by an integer of


### PR DESCRIPTION
Fixes #30. I have written some custom functions to convert `mne.Annotations` into a suitable (n, 3) ndarray - the question is where should I include these functions? Maybe the best place would be directly in MNE. Here's the code:

```
def annotations_to_array(annotations, fs):
    array = np.zeros((len(annotations), 3), dtype=int)
    ids = _unique_ids(annotations.description)
    for row, annotation in enumerate(annotations):
        array[row, 0] = annotation["onset"] * fs
        array[row, 1] = ids[annotation["description"]]
        array[row, 2] = annotation["duration"] * fs
    return array

def _unique_ids(ids):
    ids = {id: _str_to_id(id) for id in ids}
    for k, v in ids.items():
        if v is None:
            ids[k] = _unused_id(ids)
    return ids


def _unused_id(ids):
    id = 0
    while id in ids.values():
        id += 1
    return id

def _str_to_id(s):
   number = "".join([c for c in s if c.isdigit()])
   if number:
       return int(number)
   else:
       return None
```

So if you want to convert existing annotations, you call `events = annotations_to_array(raw.annotations, raw.info["sfreq"])`. This gives something very similar to what you get with `mne.events_from_annotations`, but with a valid duration column and better(TM) mapping of descriptions to event IDs.

Example using [this dataset](https://physionet.org/content/eegmmidb/1.0.0/S001/S001R04.edf):
```
import mne

raw = mne.io.read_raw_edf("S001R04.edf", preload=True)
events1 = annotations_to_array(raw.annotations, raw.info["sfreq"])
events2 = mne.events_from_annotations(raw)
```

Original `raw.annotations.description`:
```
array(['T0', 'T2', 'T0', 'T1', 'T0', 'T1', 'T0', 'T2', 'T0', 'T2', 'T0',
       'T1', 'T0', 'T2', 'T0', 'T1', 'T0', 'T2', 'T0', 'T1', 'T0', 'T1',
       'T0', 'T2', 'T0', 'T1', 'T0', 'T2', 'T0', 'T1'], dtype='<U2')
```

`events1` (note that the numbers match the numbers found in 'T0', 'T1', and 'T2', plus there is a valid durations column):
```
array([[    0,     0,   672],
       [  672,     2,   656],
       [ 1328,     0,   672],
       [ 2000,     1,   656],
       [ 2656,     0,   672],
       [ 3328,     1,   656],
       [ 3984,     0,   672],
       [ 4656,     2,   656],
       [ 5312,     0,   672],
       [ 5984,     2,   656],
       [ 6640,     0,   672],
       [ 7312,     1,   656],
       [ 7968,     0,   672],
       [ 8640,     2,   656],
       [ 9296,     0,   672],
       [ 9968,     1,   656],
       [10624,     0,   672],
       [11296,     2,   656],
       [11952,     0,   672],
       [12624,     1,   656],
       [13280,     0,   672],
       [13952,     1,   656],
       [14608,     0,   672],
       [15280,     2,   656],
       [15936,     0,   672],
       [16608,     1,   656],
       [17264,     0,   672],
       [17936,     2,   656],
       [18592,     0,   672],
       [19264,     1,   656]])
```

`events2` (note that event IDs start at 1 so they don't match 'T0', 'T1', and 'T2', plus the second column is redundant and doesn't contain any information):
```
(array([[    0,     0,     1],
        [  672,     0,     3],
        [ 1328,     0,     1],
        [ 2000,     0,     2],
        [ 2656,     0,     1],
        [ 3328,     0,     2],
        [ 3984,     0,     1],
        [ 4656,     0,     3],
        [ 5312,     0,     1],
        [ 5984,     0,     3],
        [ 6640,     0,     1],
        [ 7312,     0,     2],
        [ 7968,     0,     1],
        [ 8640,     0,     3],
        [ 9296,     0,     1],
        [ 9968,     0,     2],
        [10624,     0,     1],
        [11296,     0,     3],
        [11952,     0,     1],
        [12624,     0,     2],
        [13280,     0,     1],
        [13952,     0,     2],
        [14608,     0,     1],
        [15280,     0,     3],
        [15936,     0,     1],
        [16608,     0,     2],
        [17264,     0,     1],
        [17936,     0,     3],
        [18592,     0,     1],
        [19264,     0,     2]]), {'T0': 1, 'T1': 2, 'T2': 3})
```

Of course, `annotations_to_array` could also return the mapping just like `mne.events_from_annotations` does.

WDYT (also including @agramfort, @massich, and @larsoner regarding the inclusion of these functions into MNE)?