### PR TITLE
ENH: Add unit parameter to write_brainvision

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ collection of BrainVision files on disk.
 
     # for further parameters see our API documentation in the docs
     write_brainvision(data, sfreq, ch_names, fname, tmpdir, events,
-                      resolution=1e-6, fmt='binary_float32')
+                      resolution=1e-6, unit='µV', fmt='binary_float32')
 
 Reading BrainVision files
 -------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,10 @@ Here we list a changelog of pybv.
 Current
 =======
 
+Changelog
+~~~~~~~~~
+- Add ``unit`` parameter for exporting signals in a specific unit (V, mV, µV or uV, nV) by `Clemens Brunner`_ (`#39 <https://github.com/bids-standard/pybv/pull/39>`_)
+
 0.2.0
 =====
 

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -28,15 +28,15 @@ supported_orients = {'multiplexed'}
 
 
 def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
-                      events=None, resolution=1e-7, scale_data=True,
-                      fmt='binary_float32', meas_date=None, unit='µV'):
+                      events=None, resolution=1e-7, unit='µV', scale_data=True,
+                      fmt='binary_float32', meas_date=None):
     """Write raw data to BrainVision format.
 
     Parameters
     ----------
     data : ndarray, shape (n_channels, n_times)
-        The raw data to export. Data is assumed to be in
-        **volts**. The data will be stored in **microvolts**.
+        The raw data to export. Data is assumed to be in **volts** and will be
+        stored as specified in ``unit``.
     sfreq : int | float
         The sampling frequency of the data
     ch_names : list of strings, shape (n_channels,)
@@ -54,12 +54,13 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
         third column specifies the length of each event (default 1 sample).
     resolution : float | ndarray
         The resolution **in volts** in which you'd like the data to be stored.
-        By default, this will be 1e-7, or .1 microvolts. Since data is stored
-        in microvolts, the data will be multiplied by the inverse of this
-        factor, and all decimals will be cut off after this. So, this number
-        controls the amount of round-trip resolution you want.
-        This can be either a single float for all channels or an array with
-        nchan elements.
+        By default, this will be 1e-7, or .1 microvolts. This number controls
+        the amount of round-trip resolution. This can be either a single float
+        for all channels or an array with nchan elements.
+    unit : str
+        The unit of the exported data. This can be one of 'V', 'mV', 'µV' (or
+        equivallently 'uV') , 'nV' or 'auto'. If 'auto', a suitable unit based
+        on the selected resolution is chosen automatically.
     scale_data : bool
         Boolean indicating if the data is in volts and should be scaled to
         `resolution` (True), or if the data is already in the previously
@@ -74,10 +75,6 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
         ('u' stands for microseconds). Note that setting a measurement date
         implies that one additional event is created in the .vmrk file. To
         prevent this, set this parameter to None (default).
-    unit : str
-        The unit of the exported data. This can be one of 'V', 'mV', 'uV',
-        'µV', 'nV' or 'auto'. If 'auto', a suitable unit based on the selected
-        resolution is chosen automatically.
     """
     # Create output file names/paths
     if not op.isdir(folder_out):

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -57,10 +57,10 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
         By default, this will be 1e-7, or 0.1 µV. This number controls the
         amount of round-trip resolution. This can be either a single float for
         all channels or an array with n_channels elements.
-    unit : str
+    unit : str | None
         The unit of the exported data. This can be one of 'V', 'mV', 'µV' (or
-        equivalently 'uV') , 'nV' or 'auto'. If 'auto', a suitable unit based
-        on the selected resolution is chosen automatically.
+        equivalently 'uV') , 'nV' or None. If None, a suitable unit based on
+        the selected resolution is chosen automatically.
     scale_data : bool
         Boolean indicating if the data is in volts and should be scaled to
         `resolution` (True), or if the data is already in the previously
@@ -208,7 +208,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
 def _optimize_channel_unit(resolution, unit):
     """Calculate an optimal channel scaling factor and unit."""
     exp = np.log10(resolution)
-    if unit == 'auto':
+    if unit is None:
         if exp <= -7:
             return resolution / 1e-9, 'nV'
         elif exp <= -2:

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -276,8 +276,10 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
 
         for i in range(nchan):
             resolution, unit = _optimize_channel_unit(resolutions[i], units[i])
-            print(r'Ch{}={},,{:0.3f},{}'
-                  .format(i + 1, ch_names[i], resolution, unit), file=fout)
+            s = r'Ch{}={},,{:0.{precision}f},{}'
+            print(s.format(i + 1, ch_names[i], resolution, unit,
+                           precision=max(0, int(np.log10(1 / resolution)))),
+                  file=fout)
         print(r'', file=fout)
         print(r'[Comment]', file=fout)
         print(r'', file=fout)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -36,7 +36,7 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
     ----------
     data : ndarray, shape (n_channels, n_times)
         The raw data to export. Data is assumed to be in **volts** and will be
-        stored as specified in ``unit``.
+        stored as specified by `unit`.
     sfreq : int | float
         The sampling frequency of the data
     ch_names : list of strings, shape (n_channels,)
@@ -54,12 +54,12 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
         third column specifies the length of each event (default 1 sample).
     resolution : float | ndarray
         The resolution **in volts** in which you'd like the data to be stored.
-        By default, this will be 1e-7, or .1 microvolts. This number controls
-        the amount of round-trip resolution. This can be either a single float
-        for all channels or an array with nchan elements.
+        By default, this will be 1e-7, or 0.1 µV. This number controls the
+        amount of round-trip resolution. This can be either a single float for
+        all channels or an array with n_channels elements.
     unit : str
         The unit of the exported data. This can be one of 'V', 'mV', 'µV' (or
-        equivallently 'uV') , 'nV' or 'auto'. If 'auto', a suitable unit based
+        equivalently 'uV') , 'nV' or 'auto'. If 'auto', a suitable unit based
         on the selected resolution is chosen automatically.
     scale_data : bool
         Boolean indicating if the data is in volts and should be scaled to

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from pybv import __version__
 
-# ascii as future formats
+# ASCII as future formats
 supported_formats = {
     'binary_float32' : ('IEEE_FLOAT_32', np.float32),  # noqa: E203
     'binary_int16'   : ('INT_16', np.int16),  # noqa: E203
@@ -166,11 +166,11 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
     """Write BrainvVision marker file."""
     with codecs.open(vmrk_fname, 'w', encoding='utf-8') as fout:
         print(r'Brain Vision Data Exchange Marker File, Version 1.0', file=fout)  # noqa: E501
-        print(r';Exported using pybv {}'.format(__version__), file=fout)  # noqa: E501
+        print(r';Exported using pybv {}'.format(__version__), file=fout)
         print(r'', file=fout)
         print(r'[Common Infos]', file=fout)
         print(r'Codepage=UTF-8', file=fout)
-        print(r'DataFile={}'.format(eeg_fname.split(os.sep)[-1]), file=fout)  # noqa: E501
+        print(r'DataFile={}'.format(eeg_fname.split(os.sep)[-1]), file=fout)
         print(r'', file=fout)
         print(r'[Marker Infos]', file=fout)
         print(r'; Each entry: Mk<Marker number>=<Type>,<Description>,<Position in data points>,', file=fout)  # noqa: E501
@@ -235,13 +235,13 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
     multiplexed = _chk_multiplexed(orientation)
 
     with codecs.open(vhdr_fname, 'w', encoding='utf-8') as fout:
-        print(r'Brain Vision Data Exchange Header File Version 1.0', file=fout)  # noqa: E501
-        print(r';Written using pybv {}'.format(__version__), file=fout)  # noqa: E501
+        print(r'Brain Vision Data Exchange Header File Version 1.0', file=fout)
+        print(r';Written using pybv {}'.format(__version__), file=fout)
         print(r'', file=fout)
         print(r'[Common Infos]', file=fout)
         print(r'Codepage=UTF-8', file=fout)
-        print(r'DataFile={}'.format(op.basename(eeg_fname)), file=fout)  # noqa: E501
-        print(r'MarkerFile={}'.format(op.basename(vmrk_fname)), file=fout)  # noqa: E501
+        print(r'DataFile={}'.format(op.basename(eeg_fname)), file=fout)
+        print(r'MarkerFile={}'.format(op.basename(vmrk_fname)), file=fout)
 
         if fmt.startswith('binary'):
             print(r'DataFormat=BINARY', file=fout)
@@ -250,14 +250,14 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
             print(r'; DataOrientation: MULTIPLEXED=ch1,pt1, ch2,pt1 ...', file=fout)  # noqa: E501
             print(r'DataOrientation=MULTIPLEXED', file=fout)
 
-        print(r'NumberOfChannels={}'.format(len(data)), file=fout)  # noqa: E501
+        print(r'NumberOfChannels={}'.format(len(data)), file=fout)
         print(r'; Sampling interval in microseconds', file=fout)
-        print(r'SamplingInterval={}'.format(int(1e6 / sfreq)), file=fout)  # noqa: E501
+        print(r'SamplingInterval={}'.format(int(1e6 / sfreq)), file=fout)
         print(r'', file=fout)
 
         if fmt.startswith('binary'):
             print(r'[Binary Infos]', file=fout)
-            print(r'BinaryFormat={}'.format(bvfmt), file=fout)  # noqa: E501
+            print(r'BinaryFormat={}'.format(bvfmt), file=fout)
             print(r'', file=fout)
 
         print(r'[Channel Infos]', file=fout)

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -136,7 +136,7 @@ def test_scale_data():
 
 
 @pytest.mark.parametrize("resolution", np.logspace(-3, -9, 7))
-@pytest.mark.parametrize("unit", ["V", "mV", "uV", "µV", "nV"])
+@pytest.mark.parametrize("unit", ["V", "mV", "uV", "µV", "nV", None])
 def test_unit_resolution(resolution, unit):
     """Test different combinations of units and resolutions."""
     tmpdir = _mktmpdir()

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -21,16 +21,16 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from pybv.io import write_brainvision, _write_bveeg_file, _write_vhdr_file
 
-# Create data we'll use for testing
+# create testing data
 fname = 'pybv'
 np.random.seed(1337)
 n_chans = 10
-ch_names = ['ch_{}'.format(ii) for ii in range(n_chans)]
-sfreq = 1000.
+ch_names = ['ch_{}'.format(i) for i in range(n_chans)]
+sfreq = 1000
 n_seconds = 5
-n_times = int(n_seconds * sfreq)
-event_times = np.array([1., 2., 3., 4.])
-events = np.column_stack([(event_times * sfreq).astype(int), [1, 1, 2, 2]])
+n_times = n_seconds * sfreq
+event_times = np.arange(1, 5)
+events = np.column_stack([event_times * sfreq, [1, 1, 2, 2]])
 data = np.random.randn(n_chans, n_times)
 
 
@@ -43,24 +43,23 @@ def test_bv_writer_events():
     """Test that all event options work without throwing an error."""
     tmpdir = _mktmpdir()
 
-    # Events should be none or ndarray
+    # events should be none or ndarray
     with pytest.raises(ValueError):
         write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=[])
 
-    # Correct arguments should work
+    # correct arguments should work
     write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=events)
     write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=None)
     rmtree(tmpdir)
 
 
 def test_bv_bad_format():
-    """Test that bad formats cause an error."""
+    """Test that bad formats throw an error."""
     tmpdir = _mktmpdir()
 
-    vhdr_fname = os.path.join(tmpdir, fname+".vhdr")
-    vmrk_fname = os.path.join(tmpdir, fname+".vmrk")
-    eeg_fname = os.path.join(tmpdir, fname+".eeg")
-    # events = np.array([[10, 0, 31]])
+    vhdr_fname = os.path.join(tmpdir, fname + ".vhdr")
+    vmrk_fname = os.path.join(tmpdir, fname + ".vmrk")
+    eeg_fname = os.path.join(tmpdir, fname + ".eeg")
 
     with pytest.raises(ValueError):
         _write_vhdr_file(vhdr_fname, vmrk_fname,
@@ -86,44 +85,41 @@ def test_bad_meas_date(meas_date, match):
     with pytest.raises(ValueError, match=match):
         write_brainvision(data, sfreq, ch_names, fname, tmpdir,
                           meas_date=meas_date)
-
     rmtree(tmpdir)
 
 
 @pytest.mark.parametrize("meas_date",
                          [('20000101120000000000'),
                           (datetime(2000, 1, 1, 12, 0, 0, 0))])
-def test_bv_writer_oi_cycle(meas_date):
-    """Test that a write-read cycle produces identical data."""
+def test_write_read_cycle(meas_date):
+    """Test that a write/read cycle produces identical data."""
     tmpdir = _mktmpdir()
 
-    # Write, then read the data to BV format
+    # write and read data to BV format
     write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=events,
                       resolution=np.power(10., -np.arange(10)),
                       meas_date=meas_date)
     vhdr_fname = op.join(tmpdir, fname + '.vhdr')
     raw_written = mne.io.read_raw_brainvision(vhdr_fname, preload=True)
-    # Delete the first annotation because it's just marking a new segment
+    # delete the first annotation because it's just marking a new segment
     raw_written.annotations.delete(0)
-    # Convert our annotations to events
+    # convert our annotations to events
     events_written, event_id = mne.events_from_annotations(raw_written)
 
     # sfreq
     assert sfreq == raw_written.info['sfreq']
 
-    # Event timing should be exactly the same
+    # event timing should be exactly the same
     assert_array_equal(events[:, 0], events_written[:, 0])
     assert_array_equal(events[:, 1], events_written[:, 2])
-    # Should be 2 unique event types
-    assert len(event_id) == 2
 
-    # data round-trip.
-    assert_allclose(data, raw_written._data)
+    assert len(event_id) == 2  # there should be two unique event types
 
-    # channels
-    assert ch_names == raw_written.ch_names
+    assert_allclose(data, raw_written._data)  # data round-trip
 
-    # measurement date, we do not test microsecs
+    assert ch_names == raw_written.ch_names  # channels
+
+    # measurement dates must match
     assert raw_written.info['meas_date'] == datetime(2000, 1, 1, 12, 0, 0, 0,
                                                      tzinfo=timezone.utc)
 
@@ -149,3 +145,4 @@ def test_unit_resolution(resolution, unit):
     vhdr_fname = op.join(tmpdir, fname + '.vhdr')
     raw_written = mne.io.read_raw_brainvision(vhdr_fname, preload=True)
     assert np.allclose(data, raw_written.get_data())
+    rmtree(tmpdir)

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -137,3 +137,15 @@ def test_scale_data():
     data_written = np.fromfile(tmpdir + '/' + fname + '.eeg', dtype=np.float32)
     assert_allclose(data_written, data.T.flatten())
     rmtree(tmpdir)
+
+
+@pytest.mark.parametrize("resolution", np.logspace(-3, -9, 7))
+@pytest.mark.parametrize("unit", ["V", "mV", "uV", "µV", "nV"])
+def test_unit_resolution(resolution, unit):
+    """Test different combinations of units and resolutions."""
+    tmpdir = _mktmpdir()
+    write_brainvision(data, sfreq, ch_names, fname, tmpdir,
+                      resolution=resolution, unit=unit)
+    vhdr_fname = op.join(tmpdir, fname + '.vhdr')
+    raw_written = mne.io.read_raw_brainvision(vhdr_fname, preload=True)
+    assert np.allclose(data, raw_written.get_data())


### PR DESCRIPTION
Fixes #38.

Test with the following code snippet (this could be included as a proper test):

```python
from pathlib import Path
import numpy as np
import mne
from mne.io import read_raw_brainvision
import pybv


rng = np.random.default_rng(42)
data = rng.normal(loc=0, scale=1e-5, size=(10, 10000))  # typical EEG scale
info = mne.create_info(10, 256, "eeg")
raw1 = mne.io.RawArray(data, info)

fpath = "."
fname = "export"
resolution = 1e-7
unit = "µV"  # "V", "mV", "uV", "µV", "nV", "auto"

pybv.write_brainvision(data=raw1.get_data(),  # always in V
                       sfreq=raw1.info["sfreq"],
                       ch_names=raw1.info["ch_names"],
                       fname_base=fname,
                       folder_out=fpath,
                       events=None,
                       resolution=resolution,
                       scale_data=True,
                       meas_date=None,
                       unit=unit)

raw2 = read_raw_brainvision(Path(fpath) / (fname + ".vhdr"), preload=True)

print(np.allclose(raw1.get_data(), raw2.get_data()))
print(np.max(np.abs(raw1.get_data() - raw2.get_data())))
```


This is still WIP because the following issues must be resolved:

1. Currently this does not work for `unit = 'mV'` - the checks at the end return `False` and a maximum difference of 0.05 (instead of around 1e-12 for all other cases). Any ideas?
2. The position of the `unit` parameter at the end is not ideal, if we can sacrifice backwards compatibility I'd move it directly after `resolution`.
```
