### PR TITLE
FIX: support for for commas in channel names

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,10 @@ Changelog
 ~~~~~~~~~
 - Passing a "greek small letter mu" instead of a "micro sign" as a ``unit`` is now permitted, because :func:`pybv.write_brainvision` will convert from one to the other, by `Stefan Appelhoff`_ (`#47 <https://github.com/bids-standard/pybv/pull/47>`_)
 
+Bug
+~~~
+- ``pybv`` now properly substitutes commas in channel names with ``\1`` before writing to file, and passing non-numeric events now raises a ValueError, by `Stefan Appelhoff`_ (`#53 <https://github.com/bids-standard/pybv/pull/53>`_)
+
 Authors
 ~~~~~~~
 - `Stefan Appelhoff`_

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -292,9 +292,10 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
         units = [unit] * nchan
 
         for i in range(nchan):
+            _ch_name = ch_names[i].replace(',', r'\1')
             resolution, unit = _optimize_channel_unit(resolutions[i], units[i])
             s = r'Ch{}={},,{:0.{precision}f},{}'
-            print(s.format(i + 1, ch_names[i], resolution, unit,
+            print(s.format(i + 1, _ch_name, resolution, unit,
                            precision=max(0, int(np.log10(1 / resolution)))),
                   file=fout)
         print(r'', file=fout)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -56,6 +56,8 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
         (corresponding to the "time" dimension of the data array). The second
         column is a number associated with the "type" of event. The (optional)
         third column specifies the length of each event (default 1 sample).
+        Currently all events are written as type "Stimulus" and must be
+        numeric.
         Defaults to None (not writing any events).
     resolution : float | ndarray
         The resolution **in volts** in which you'd like the data to be stored.
@@ -90,13 +92,17 @@ def write_brainvision(data, sfreq, ch_names, fname_base, folder_out,
 
     # Input checks
     ev_err = ("events must be an ndarray of shape (n_events, 2) or "
-              "(n_events, 3) or None")
+              "(n_events, 3) containing numeric values, or None")
     if not isinstance(events, (np.ndarray, type(None))):
         raise ValueError(ev_err)
     if isinstance(events, np.ndarray):
         if events.ndim != 2:
             raise ValueError(ev_err)
         if events.shape[1] not in (2, 3):
+            raise ValueError(ev_err)
+        try:
+            events.astype(float)
+        except ValueError:
             raise ValueError(ev_err)
 
     nchan = len(ch_names)
@@ -210,6 +216,8 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
         twidth = max(3, twidth)
         tformat = 'S{:>' + str(twidth) + '}'
 
+        # Currently all events are written as type "Stimulus"
+        # Currently all event descriptions must be numeric
         for marker_number, irow in enumerate(range(len(events)), start=1 if meas_date is None else 2):  # noqa: E501
             i_ix = events[irow, 0] + 1  # BrainVision uses 1-based indexing
             i_val = events[irow, 1]

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 import pytest
 
 import mne
+from mne.utils import requires_version
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
@@ -118,6 +119,7 @@ def test_bad_meas_date(meas_date, match):
     rmtree(tmpdir)
 
 
+@requires_version("mne", min_version="0.22")
 @pytest.mark.parametrize("ch_names_tricky",
                          [[ch + ' f o o' for ch in ch_names],
                           [ch + ' f%o$o' for ch in ch_names],

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -113,6 +113,25 @@ def test_bad_meas_date(meas_date, match):
     rmtree(tmpdir)
 
 
+def test_comma_in_ch_name():
+    """Test that writing channel names with commas works."""
+    tmpdir = _mktmpdir()
+
+    # make tricky ch_names
+    ch_names_tricky = [ch + ',trick' for ch in ch_names]
+
+    # write and read data to BV format
+    write_brainvision(data, sfreq, ch_names_tricky, fname, tmpdir)
+    vhdr_fname = op.join(tmpdir, fname + '.vhdr')
+    raw_written = mne.io.read_raw_brainvision(vhdr_fname, preload=True)
+
+    assert ch_names_tricky == raw_written.ch_names  # channels
+
+    assert_allclose(data, raw_written._data)  # data round-trip
+
+    rmtree(tmpdir)
+
+
 @pytest.mark.parametrize("meas_date",
                          [('20000101120000000000'),
                           (datetime(2000, 1, 1, 12, 0, 0, 0))])

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -113,12 +113,15 @@ def test_bad_meas_date(meas_date, match):
     rmtree(tmpdir)
 
 
-def test_comma_in_ch_name():
-    """Test that writing channel names with commas works."""
+@pytest.mark.parametrize("ch_names_tricky",
+                         [[ch + ' f o o' for ch in ch_names],
+                          [ch + ' f%o$o' for ch in ch_names],
+                          [ch + ',foo' for ch in ch_names],
+                          ]
+                         )
+def test_comma_in_ch_name(ch_names_tricky):
+    """Test that writing channel names with special characters works."""
     tmpdir = _mktmpdir()
-
-    # make tricky ch_names
-    ch_names_tricky = [ch + ',trick' for ch in ch_names]
 
     # write and read data to BV format
     write_brainvision(data, sfreq, ch_names_tricky, fname, tmpdir)

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -55,6 +55,11 @@ def test_bv_writer_events():
         write_brainvision(data, sfreq, ch_names, fname, tmpdir,
                           events=rng.randn(10, 4))
 
+    with pytest.raises(ValueError, match='events must be an ndarray of shape'):
+        fake_events = np.array([i for i in "abcdefghi"]).reshape(3, -1)
+        write_brainvision(data, sfreq, ch_names, fname, tmpdir,
+                          events=fake_events)
+
     # correct arguments should work
     write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=events)
     write_brainvision(data, sfreq, ch_names, fname, tmpdir, events=None)

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -122,7 +122,6 @@ def test_bad_meas_date(meas_date, match):
 @requires_version("mne", min_version="0.22")
 @pytest.mark.parametrize("ch_names_tricky",
                          [[ch + ' f o o' for ch in ch_names],
-                          [ch + ' f%o$o' for ch in ch_names],
                           [ch + ',foo' for ch in ch_names],
                           ]
                          )


### PR DESCRIPTION
closes #51 

commas in (1) event type, and (2) event description are currently irrelevant, because:

1. type is always "Stimulus" (no commas possible)
2. description is always numeric (no commas possible)