### PR TITLE
API, HUGE: rework "resolution" and follow the consequences

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ API
 
 Authors
 ~~~~~~~
+- `Clemens Brunner`_
+- `Richard Höchenberger`_
 - `Stefan Appelhoff`_
 
 0.3.0
@@ -117,3 +119,4 @@ Authors
 .. _Tristan Stenner: https://github.com/tstenner
 .. _Phillip Alday: https://palday.bitbucket.io/
 .. _Clemens Brunner: https://cbrnr.github.io/
+.. _Richard Höchenberger: https://hoechenberger.net/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,16 +17,19 @@ Current
 
 Changelog
 ~~~~~~~~~
-- Passing a "greek small letter mu" instead of a "micro sign" as a ``unit`` is now permitted, because :func:`pybv.write_brainvision` will convert from one to the other, by `Stefan Appelhoff`_ (`#47 <https://github.com/bids-standard/pybv/pull/47>`_)
+- Passing a "greek small letter mu" to the ``unit`` parameter in :func:`pybv.write_brainvision` instead of a "micro sign" is now permitted, because the one will be automatically convert to the other, by `Stefan Appelhoff`_ (`#47 <https://github.com/bids-standard/pybv/pull/47>`_)
 
 Bug
 ~~~
-- ``pybv`` now properly substitutes commas in channel names with ``\1`` before writing to file, and passing non-numeric events now raises a ValueError, by `Stefan Appelhoff`_ (`#53 <https://github.com/bids-standard/pybv/pull/53>`_)
+- Fix bug where :func:`pybv.write_brainvision` did not properly deal with commas in channel names and non-numeric events, by `Stefan Appelhoff`_ (`#53 <https://github.com/bids-standard/pybv/pull/53>`_)
 - :func:`pybv.write_brainvision` now properly handles sampling frequencies that are not multiples of 10 (even floats), by `Clemens Brunner`_ (`#59 <https://github.com/bids-standard/pybv/pull/59>`_)
+- Fix bug where :func:`pybv.write_brainvision` would write a different resolution to the ``vhdr`` file than specified with the ``resolution`` parameter. Note that this did *not* affect the roundtrip accuracy of the written data, because of internal scaling of the data, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
 
 API
 ~~~
 - :func:`pybv.write_brainvision` now accepts keyword arguments only. Positional arguments are no longer allowed, by `Stefan Appelhoff`_ (`#57 <https://github.com/bids-standard/pybv/pull/57>`_)
+- In :func:`pybv.write_brainvision`, the ``scale_data`` parameter was removed from :func:`pybv.write_brainvision`, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
+- In :func:`pybv.write_brainvision`, the ``unit`` parameter no longer accepts an argument ``None`` to automatically determined a unit based on the ``resolution``, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
 
 Authors
 ~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ Bug
 - Fix bug where :func:`pybv.write_brainvision` did not properly deal with commas in channel names and non-numeric events, by `Stefan Appelhoff`_ (`#53 <https://github.com/bids-standard/pybv/pull/53>`_)
 - :func:`pybv.write_brainvision` now properly handles sampling frequencies that are not multiples of 10 (even floats), by `Clemens Brunner`_ (`#59 <https://github.com/bids-standard/pybv/pull/59>`_)
 - Fix bug where :func:`pybv.write_brainvision` would write a different resolution to the ``vhdr`` file than specified with the ``resolution`` parameter. Note that this did *not* affect the roundtrip accuracy of the written data, because of internal scaling of the data, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
+- Fix bug where values for the ``resolution`` parameter like ``0.5``, ``0.123``, ``3.143`` were not written with adequate decimal precision in :func:`pybv.write_brainvision`, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
 
 API
 ~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,7 +17,7 @@ Current
 
 Changelog
 ~~~~~~~~~
-- Passing a "greek small letter mu" to the ``unit`` parameter in :func:`pybv.write_brainvision` instead of a "micro sign" is now permitted, because the one will be automatically convert to the other, by `Stefan Appelhoff`_ (`#47 <https://github.com/bids-standard/pybv/pull/47>`_)
+- Passing a "greek small letter mu" to the ``unit`` parameter in :func:`pybv.write_brainvision` instead of a "micro sign" is now permitted, because the former will be automatically convert to the latter, by `Stefan Appelhoff`_ (`#47 <https://github.com/bids-standard/pybv/pull/47>`_)
 
 Bug
 ~~~
@@ -29,7 +29,7 @@ API
 ~~~
 - :func:`pybv.write_brainvision` now accepts keyword arguments only. Positional arguments are no longer allowed, by `Stefan Appelhoff`_ (`#57 <https://github.com/bids-standard/pybv/pull/57>`_)
 - In :func:`pybv.write_brainvision`, the ``scale_data`` parameter was removed from :func:`pybv.write_brainvision`, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
-- In :func:`pybv.write_brainvision`, the ``unit`` parameter no longer accepts an argument ``None`` to automatically determined a unit based on the ``resolution``, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
+- In :func:`pybv.write_brainvision`, the ``unit`` parameter no longer accepts an argument ``None`` to automatically determine a unit based on the ``resolution``, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
 
 Authors
 ~~~~~~~

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -64,10 +64,12 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
         If float, the same resolution is applied to all channels.
         If ndarray with n_channels elements, each channel is scaled with
         its own corresponding resolution from the ndarray.
-        Note that if `fmt` is 'binary_int16', it is recommended to set
-        `resolution` to '0.1' (default) and `unit` to 'µV' (default).
-        For `fmt` 'binary_float32', the resolution should usually be kept
-        at its default value.
+        Note that `resolution` is applied on top of the default resolution
+        that a data format (see `fmt`) has; that is, 0 floating point
+        resolution for binary_int16, and 1e-6 floating point resolution for
+        binary_float32. For example, writing binary_int16 data in µV with
+        0.1 resolution (default) will guarantee accurate writing of data for
+        all values >= 0.1 µV.
     unit : str
         The unit of the exported data. This can be one of 'V', 'mV', 'µV' (or
         equivalently 'uV') , or 'nV'. Defaults to 'µV'.
@@ -231,7 +233,7 @@ def _scale_data_to_unit(data, unit):
     else:
         raise ValueError(
             f'Encountered unsupported unit: {unit}'
-            '\nUse one of the following: {SUPPORTED_UNITS}')
+            f'\nUse one of the following: {SUPPORTED_UNITS}')
 
 
 def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -126,6 +126,9 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
     if resolution.shape != (1,) and resolution.shape != (nchan,):
         raise ValueError("Resolution should be one or n_chan floats")
 
+    if np.any(resolution <= 0):
+        raise ValueError("Resolution should be > 0")
+
     _chk_fmt(fmt)
 
     if unit == 'μV':

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -283,10 +283,10 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
 
         for i in range(nchan):
             _ch_name = ch_names[i].replace(',', r'\1')
-            resolution, unit = _optimize_channel_unit(resolutions[i], units[i])
-            precision = max(0, int(np.log10(1 / resolution)))
-            print(f'Ch{i + 1}={_ch_name},,{resolution:0.{precision}f},{unit}',
-                  file=fout)
+            resolution = np.format_float_positional(resolutions[i], trim="-")
+            unit = units[i]
+            print(f'Ch{i + 1}={_ch_name},,{resolution},{unit}', file=fout)
+
         print('', file=fout)
         print('[Comment]', file=fout)
         print('', file=fout)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -66,11 +66,14 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
         If ndarray with n_channels elements, each channel is scaled with
         its own corresponding resolution from the ndarray.
         Note that `resolution` is applied on top of the default resolution
-        that a data format (see `fmt`) has; that is, 0 floating point
-        resolution for binary_int16, and 1e-6 floating point resolution for
-        binary_float32. For example, writing binary_int16 data in µV with
-        0.1 resolution (default) will guarantee accurate writing of data for
-        all values >= 0.1 µV.
+        that a data format (see `fmt`) has. For example, the binary_int16
+        format by design has no floating point support, but when scaling the
+        data in µV for 0.1 resolution (default), accurate writing for all
+        values >= 0.1 µV will be guaranteed. In contrast, the binary_float32
+        format by design already supports floating points up to 1e-6
+        resolution, and writing data in µV with 0.1 resolution will thus
+        guarantee accurate writing vor all values >= 1e-7 µV
+        (``1e-6 * 0.1``).
     unit : str
         The unit of the exported data. This can be one of 'V', 'mV', 'µV' (or
         equivalently 'uV') , or 'nV'. Defaults to 'µV'.

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -6,6 +6,7 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #          Tristan Stenner <stenner@med-psych.uni-kiel.de>
 #          Clemens Brunner <clemens.brunner@gmail.com>
+#          Richard Höchenberger <richard.hoechenberger@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -94,6 +94,9 @@ def test_bv_writer_inputs():
     with pytest.raises(ValueError, match='Resolution should be numeric, is'):
         write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
                           fname_base=fname, folder_out=tmpdir, resolution='y')
+    with pytest.raises(ValueError, match='Resolution should be > 0'):
+        write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
+                          fname_base=fname, folder_out=tmpdir, resolution=0)
     with pytest.raises(ValueError, match='Resolution should be one or n_chan'):
         write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
                           fname_base=fname, folder_out=tmpdir,

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -216,8 +216,12 @@ def test_write_read_cycle(meas_date):
 
 
 # XXX: test also binary_int16 here
+resolutions = np.logspace(0, -9, 10)
+resolutions = np.hstack((resolutions, [np.pi, 0.5, 0.27e-6, 13]))
+
+
 @pytest.mark.parametrize("format", ["binary_float32"])
-@pytest.mark.parametrize("resolution", np.logspace(-1, -9, 9))
+@pytest.mark.parametrize("resolution", resolutions)
 @pytest.mark.parametrize("unit", ["V", "mV", "uV", "µV", "nV"])
 def test_unit_resolution(format, resolution, unit):
     """Test different combinations of units and resolutions."""

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -4,7 +4,9 @@
 # Authors: Phillip Alday <phillip.alday@unisa.edu.au>
 #          Chris Holdgraf <choldgraf@berkeley.edu>
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#          Tristan Stenner <stenner@med-psych.uni-kiel.de>
 #          Clemens Brunner <clemens.brunner@gmail.com>
+#          Richard Höchenberger <richard.hoechenberger@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -14,9 +16,9 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 import mne
-from mne.utils import requires_version
 import numpy as np
 import pytest
+from mne.utils import requires_version
 from numpy.testing import assert_allclose, assert_array_equal
 
 from pybv.io import _write_bveeg_file, _write_vhdr_file, write_brainvision
@@ -244,7 +246,7 @@ def test_sampling_frequencies(sfreq):
     tmpdir = _mktmpdir()
     # sampling frequency gets written as sampling interval
     write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
-                      fname_base=fname, folder_out=tmpdir, scale_data=False)
+                      fname_base=fname, folder_out=tmpdir)
     vhdr_fname = os.path.join(tmpdir, fname + '.vhdr')
     raw_written = mne.io.read_raw_brainvision(vhdr_fname=vhdr_fname,
                                               preload=True)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@
 # Authors: Phillip Alday <phillip.alday@unisa.edu.au>
 #          Chris Holdgraf <choldgraf@berkeley.edu>
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#          Tristan Stenner <stenner@med-psych.uni-kiel.de>
+#          Clemens Brunner <clemens.brunner@gmail.com>
+#          Richard Höchenberger <richard.hoechenberger@gmail.com>
 #
 # License: BSD (3-clause)
 


### PR DESCRIPTION
closes https://github.com/bids-standard/pybv/issues/49

also closes closes #48

this commit makes some huge changes in order to align the way pybv
saves data more with the BrainVision data format specification.

- the data is now converted to units, and then scaled to resolution,
  and only then written to disk

- resolution is written *as is* to the VHDR file (as is the case for
  unit)

- passing None for unit is removed, unit has to be passed explicitly
  (defaults to µV)

- the scale_data parameter is removed entirely, because with the new
  way that resolution works, it has become meaningless and passing
  resolution=1 takes over the same functionality


to do:

- [x] add whatsnew
- ~rename unit_resolution test to unit_resolution_format or the like~ will do in follow-up PR