### PR TITLE
FIX: do not write data if it cannot be represented in fmt, given unit and resolution

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -57,7 +57,6 @@ jobs:
     - name: Check formatting
       if: "matrix.platform == 'ubuntu-18.04'"
       run: |
-        isort pybv
         flake8 --docstring-convention numpy .
         pycodestyle pybv
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,9 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# View the built documentation
+view:
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/_build/html/index.html')"
+
+show: view

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ Bug
 - :func:`pybv.write_brainvision` now properly handles sampling frequencies that are not multiples of 10 (even floats), by `Clemens Brunner`_ (`#59 <https://github.com/bids-standard/pybv/pull/59>`_)
 - Fix bug where :func:`pybv.write_brainvision` would write a different resolution to the ``vhdr`` file than specified with the ``resolution`` parameter. Note that this did *not* affect the roundtrip accuracy of the written data, because of internal scaling of the data, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
 - Fix bug where values for the ``resolution`` parameter like ``0.5``, ``0.123``, ``3.143`` were not written with adequate decimal precision in :func:`pybv.write_brainvision`, by `Stefan Appelhoff`_ (`#58 <https://github.com/bids-standard/pybv/pull/58>`_)
+- Fix bug where :func:`pybv.write_brainvision` did not warn users that a particular combination of ``fmt``, ``unit``, and ``resolution`` can lead to broken data. For example high resolution µV data in int16 format. In such cases, an error is raised now, by `Stefan Appelhoff`_ (`#62 <https://github.com/bids-standard/pybv/pull/62>`_)
 
 API
 ~~~

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -232,8 +232,8 @@ def _scale_data_to_unit(data, unit):
     """Scale `data` in Volts to `data` in `unit`."""
     scale = SUPPORTED_UNITS.get(unit, None)
     if not isinstance(scale, float):
-        msg = (f'Encountered unsupported unit: {unit}'
-               f'\nUse one of the following: {set(SUPPORTED_UNITS.keys())}')
+        msg = (f'Encountered unsupported unit: {unit}\n'
+               f'Use one of the following: {set(SUPPORTED_UNITS.keys())}')
         raise ValueError(msg)
 
     return data * scale
@@ -295,7 +295,7 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,
 
 
 def _check_data_in_range(data, dtype):
-    """Check that data can be represented in dtype."""
+    """Check that data can be represented by dtype."""
     check_funcs = {np.int16: np.iinfo, np.float32: np.finfo}
     fun = check_funcs.get(dtype, None)
     if fun is None:  # pragma: no cover

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -231,7 +231,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
 def _scale_data_to_unit(data, unit):
     """Scale `data` in Volts to `data` in `unit`."""
     scale = SUPPORTED_UNITS.get(unit, None)
-    if not isinstance(scale, float):
+    if scale is None:
         msg = (f'Encountered unsupported unit: {unit}\n'
                f'Use one of the following: {set(SUPPORTED_UNITS.keys())}')
         raise ValueError(msg)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -28,7 +28,7 @@ SUPPORTED_FORMATS = {
 
 SUPPORTED_ORIENTS = {'multiplexed'}
 
-SUPPORTED_UNITS = ['V', 'mV', 'µV', 'uV', 'nV']
+SUPPORTED_UNITS = {'V': 1e0, 'mV': 1e3, 'µV': 1e6, 'uV': 1e6, 'nV': 1e9}
 
 
 def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
@@ -229,18 +229,13 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
 
 def _scale_data_to_unit(data, unit):
     """Scale `data` in Volts to `data` in `unit`."""
-    if unit == 'V':
-        return data
-    elif unit == 'mV':
-        return data * 1e3
-    elif unit in ('µV', 'uV'):
-        return data * 1e6
-    elif unit == 'nV':
-        return data * 1e9
-    else:
-        raise ValueError(
-            f'Encountered unsupported unit: {unit}'
-            f'\nUse one of the following: {SUPPORTED_UNITS}')
+    scale = SUPPORTED_UNITS.get(unit, None)
+    if not isinstance(scale, float):
+        msg = (f'Encountered unsupported unit: {unit}'
+               f'\nUse one of the following: {set(SUPPORTED_UNITS.keys())}')
+        raise ValueError(msg)
+
+    return data * scale
 
 
 def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, data, sfreq, ch_names,

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -21,7 +21,9 @@ import pytest
 from mne.utils import requires_version
 from numpy.testing import assert_allclose, assert_array_equal
 
-from pybv.io import _write_bveeg_file, _write_vhdr_file, write_brainvision, _check_data_in_range, _scale_data_to_unit, _chk_fmt, SUPPORTED_UNITS, SUPPORTED_FORMATS
+from pybv.io import (SUPPORTED_FORMATS, SUPPORTED_UNITS, _check_data_in_range,
+                     _chk_fmt, _scale_data_to_unit, _write_bveeg_file,
+                     _write_vhdr_file, write_brainvision)
 
 # create testing data
 fname = 'pybv'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest-cov
 pytest-sugar
 flake8
 flake8-docstrings
+flake8-isort
 pycodestyle
 sphinx
 numpydoc


### PR DESCRIPTION
fixes #45 

previously we allowed users to write their data in whatever combination of fmt, unit, and resolution they wanted. --> in some cases this lead to data not being accurately represented ... for example, high resolution µV data in  binary_int16 format.

In this PR I add a check to see if the data *can* be written as desired ... and if not, I raise a ValueError.