### PR TITLE
MISC maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 coverage.xml
 /coverage
 htmlcov/
+.vscode/


### PR DESCRIPTION
closes #55 

- replaces our custom tmpdir hacking with the pytest tmpdir fixture
- uses pytest.mark.parametrize for one test to make it (1) more concise, (2) more informative if failed
- "switches on" the comma test, **wich will fail until https://github.com/mne-tools/mne-python/pull/8492 is merged**

I plan that this is the last PR before release 0.4 #60 