### PR TITLE
[MRG] Improve file handling, add overwrite parameter

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -73,7 +73,7 @@ jobs:
         path: docs/_build/html
 
     - name: Upload coverage report
-      if: "matrix.platform == 'ubuntu-18.04'"
+      if: ${{ matrix.platform == 'ubuntu-18.04' && matrix.python-version == '3.9' }}
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -54,7 +54,7 @@ jobs:
         mne sys_info
 
     - name: Check formatting
-      if: "matrix.platform == 'ubuntu-18.04'"
+      if: ${{ matrix.platform == 'ubuntu-18.04' && matrix.python-version == '3.9' }}
       run: make pep
 
     - name: Test with pytest
@@ -66,7 +66,7 @@ jobs:
         make build-doc
 
     - name: Upload artifacts
-      if: "matrix.platform == 'ubuntu-18.04'"
+      if: ${{ matrix.platform == 'ubuntu-18.04' && matrix.python-version == '3.9' }}
       uses: actions/upload-artifact@v2
       with:
         name: docs-artifact

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,7 +29,10 @@ Here we list a changelog of pybv.
 Current (unreleased)
 ====================
 
-- nothing so far
+
+API
+~~~
+- :func:`pybv.write_brainvision` now has an ``overwrite`` parameter that defaults to ``False``, by `Stefan Appelhoff`_ (:gh:`78`).
 
 0.5.0 (2021-01-03)
 ==================

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import warnings
 from os import path as op
-from pathlib import Path
 from warnings import warn
 
 import numpy as np
@@ -235,7 +234,8 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
                          resolution=resolution, units=units)
     except ValueError:
         for fname in (eeg_fname, vmrk_fname, vhdr_fname):
-            Path(fname).unlink(missing_ok=True)
+            if op.exists(fname):
+                os.remove(fname)
         if folder_out_created:
             shutil.rmtree(folder_out)
         raise

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -15,7 +15,6 @@ import codecs
 import datetime
 import os
 import shutil
-import warnings
 from os import path as op
 from warnings import warn
 
@@ -195,7 +194,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
 
     # only show the warning once if a greek letter was encountered
     if show_warning:
-        warnings.warn(
+        warn(
             f"Encountered small Greek letter mu 'μ' or 'u' in unit: {unit}. "
             f"Converting to micro sign 'µ'."
         )
@@ -226,6 +225,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
 
     # Write output files, but delete everything if we come across an error
     try:
+
         _write_bveeg_file(eeg_fname, data, orientation='multiplexed',
                           format=fmt, resolution=resolution, units=units)
         _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -37,8 +37,11 @@ SUPPORTED_VOLTAGE_SCALINGS = {
 
 def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
                       overwrite=False,
-                      events=None, resolution=0.1, unit='µV',
-                      fmt='binary_float32', meas_date=None):
+                      events=None,
+                      resolution=0.1,
+                      unit='µV',
+                      fmt='binary_float32',
+                      meas_date=None):
     """Write raw data to BrainVision format [1]_.
 
     Parameters
@@ -49,7 +52,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
         specified by ``unit``) are never scaled (e.g. ``'°C'``).
     sfreq : int | float
         The sampling frequency of the data.
-    ch_names : list of str, shape (n_channels,)
+    ch_names : list of {str | int}, shape (n_channels,)
         The name of each channel.
     fname_base : str
         The base name for the output files. Three files will be created
@@ -148,7 +151,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
     nchan = len(ch_names)
     for ch in ch_names:
         if not isinstance(ch, (str, int)):
-            raise ValueError("ch_names must be a list of str.")
+            raise ValueError("ch_names must be a list of str or list of int.")
     ch_names = [str(ch) for ch in ch_names]
 
     if len(data) != nchan:
@@ -219,7 +222,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
     for fname in (eeg_fname, vmrk_fname, vhdr_fname):
         if op.exists(fname) and not overwrite:
             raise IOError(f"File already exists: {fname}.\n"
-                          f"Consider setting overwrite=True."))
+                          f"Consider setting overwrite=True.")
 
     # Write output files, but delete everything if we come across an error
     try:

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -237,7 +237,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
         else:
             # else, only remove the files we might have created
             for fname in (eeg_fname, vmrk_fname, vhdr_fname):
-                if op.exists(fname):
+                if op.exists(fname):  # pragma: no cover
                     os.remove(fname)
 
         raise

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -233,11 +233,15 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
                          ch_names, orientation='multiplexed', format=fmt,
                          resolution=resolution, units=units)
     except ValueError:
-        for fname in (eeg_fname, vmrk_fname, vhdr_fname):
-            if op.exists(fname):
-                os.remove(fname)
         if folder_out_created:
+            # if this is a new folder, remove everything
             shutil.rmtree(folder_out)
+        else:
+            # else, only remove the files we might have created
+            for fname in (eeg_fname, vmrk_fname, vhdr_fname):
+                if op.exists(fname):
+                    os.remove(fname)
+
         raise
 
 

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -216,10 +216,10 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
     eeg_fname = op.join(folder_out, fname_base + '.eeg')
     vmrk_fname = op.join(folder_out, fname_base + '.vmrk')
     vhdr_fname = op.join(folder_out, fname_base + '.vhdr')
-    msg = "File already exists: {}.\nConsider setting overwrite=True."
     for fname in (eeg_fname, vmrk_fname, vhdr_fname):
         if op.exists(fname) and not overwrite:
-            raise IOError(msg.format(fname))
+            raise IOError(f"File already exists: {fname}.\n"
+                          f"Consider setting overwrite=True."))
 
     # Write output files, but delete everything if we come across an error
     try:

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -131,7 +131,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
 
     """
     # Input checks
-    if not isinstance(overwrite, bool) and overwrite not in [0, 1]:
+    if not isinstance(overwrite, bool):
         raise ValueError("overwrite must be a boolean (True or False).")
 
     ev_err = ("events must be an ndarray of shape (n_events, 2) or "

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -70,7 +70,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
         third column specifies the length of each event (default 1 sample).
         Currently all events are written as type "Stimulus" and must be
         numeric. Defaults to None (not writing any events).
-    resolution : float | np.ndarray, shape(nchannels,)
+    resolution : float | np.ndarray, shape (nchannels,)
         The resolution in `unit` in which you'd like the data to be stored. If
         float, the same resolution is applied to all channels. If ndarray with
         n_channels elements, each channel is scaled with its own corresponding

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -148,6 +148,10 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
             raise ValueError(ev_err)
 
     nchan = len(ch_names)
+    for ch in ch_names:
+        if not isinstance(ch, (str, int)):
+            raise ValueError("ch_names must be a list of str.")
+    ch_names = [str(ch) for ch in ch_names]
 
     if len(data) != nchan:
         raise ValueError(f"Number of channels in data ({len(data)}) does not "

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -172,8 +172,6 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
     if np.any(resolution <= 0):
         raise ValueError("Resolution should be > 0")
 
-    _chk_fmt(fmt)
-
     # check unit is single str
     if isinstance(unit, str):
         # convert unit to list, assuming all units are the same

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -49,7 +49,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
         specified by ``unit``) are never scaled (e.g. ``'°C'``).
     sfreq : int | float
         The sampling frequency of the data.
-    ch_names : list of strings, shape (n_channels,)
+    ch_names : list of str, shape (n_channels,)
         The name of each channel.
     fname_base : str
         The base name for the output files. Three files will be created

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -52,7 +52,7 @@ def write_brainvision(*, data, sfreq, ch_names, fname_base, folder_out,
         specified by ``unit``) are never scaled (e.g. ``'°C'``).
     sfreq : int | float
         The sampling frequency of the data.
-    ch_names : list of {str | int}, shape (n_channels,)
+    ch_names : list of {str | int}, len (n_channels)
         The name of each channel.
     fname_base : str
         The base name for the output files. Three files will be created

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -11,6 +11,7 @@
 #
 # License: BSD-3-Clause
 
+import os
 import os.path as op
 from datetime import datetime, timezone
 
@@ -343,6 +344,19 @@ def test_cleanup(tmpdir):
                           fname_base=fname, folder_out=folder_out,
                           fmt="binary_float999")
     assert not op.exists(folder_out)
+    assert not op.exists(folder_out / fname + ".eeg")
+    assert not op.exists(folder_out / fname + ".vmrk")
+    assert not op.exists(folder_out / fname + ".vhdr")
+
+    # if folder already existed before erroneous writing, it is not deleted
+    os.makedirs(folder_out)
+    with pytest.raises(ValueError, match="Data format binary_float999"):
+        write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
+                          fname_base=fname, folder_out=folder_out,
+                          fmt="binary_float999")
+    assert op.exists(folder_out)
+
+    # but all other (incomplete/erroneous) files are deleted
     assert not op.exists(folder_out / fname + ".eeg")
     assert not op.exists(folder_out / fname + ".vmrk")
     assert not op.exists(folder_out / fname + ".vhdr")

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -94,7 +94,7 @@ def test_bv_writer_inputs(tmpdir):
                           resolution=np.arange(n_chans-1))
     with pytest.raises(ValueError, match='overwrite must be a boolean'):
         write_brainvision(data=data[1:, :], sfreq=sfreq, ch_names=ch_names,
-                          fname_base=fname, folder_out=tmpdir, overwrite=2)
+                          fname_base=fname, folder_out=tmpdir, overwrite=1)
 
 
 def test_bv_bad_format(tmpdir):

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -91,6 +91,9 @@ def test_bv_writer_inputs(tmpdir):
         write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
                           fname_base=fname, folder_out=tmpdir,
                           resolution=np.arange(n_chans-1))
+    with pytest.raises(ValueError, match='overwrite must be a boolean'):
+        write_brainvision(data=data[1:, :], sfreq=sfreq, ch_names=ch_names,
+                          fname_base=fname, folder_out=tmpdir, overwrite=2)
 
 
 def test_bv_bad_format(tmpdir):

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -11,6 +11,7 @@
 #
 # License: BSD-3-Clause
 
+import os.path as op
 from datetime import datetime, timezone
 
 import mne
@@ -73,6 +74,9 @@ def test_bv_writer_inputs(tmpdir):
                           fname_base=fname, folder_out=tmpdir)
     with pytest.raises(ValueError, match='Channel names must be unique'):
         write_brainvision(data=data[0:2, :], sfreq=sfreq, ch_names=['b', 'b'],
+                          fname_base=fname, folder_out=tmpdir)
+    with pytest.raises(ValueError, match='ch_names must be a list of str.'):
+        write_brainvision(data=data[0:2, :], sfreq=sfreq, ch_names=['b', 2.3],
                           fname_base=fname, folder_out=tmpdir)
     with pytest.raises(ValueError, match='sfreq must be one of '):
         write_brainvision(data=data, sfreq='100', ch_names=ch_names,
@@ -159,7 +163,7 @@ def test_write_read_cycle(tmpdir, meas_date):
                                          'non-voltage unit'):
         write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
                           fname_base=fname, folder_out=tmpdir,
-                          unit=unsupported_unit)
+                          unit=unsupported_unit, overwrite=True)
 
     # write and read data to BV format
     # ensure that greek small letter mu gets converted to micro sign
@@ -167,7 +171,7 @@ def test_write_read_cycle(tmpdir, meas_date):
         write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
                           fname_base=fname, folder_out=tmpdir, events=events,
                           resolution=np.power(10., -np.arange(10)),
-                          unit='μV', meas_date=meas_date)
+                          unit='μV', meas_date=meas_date, overwrite=True)
     vhdr_fname = tmpdir / fname + '.vhdr'
     raw_written = mne.io.read_raw_brainvision(vhdr_fname=vhdr_fname,
                                               preload=True)
@@ -288,7 +292,7 @@ def test_write_multiple_units(tmpdir, unit):
     # write file and read back in
     write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
                       fname_base=fname, folder_out=tmpdir,
-                      unit=units)
+                      unit=units, overwrite=True)
     raw_written = mne.io.read_raw_brainvision(vhdr_fname=vhdr_fname,
                                               preload=True)
 
@@ -326,3 +330,28 @@ def test_write_unsupported_units(tmpdir):
     assert len(set(orig_units)) == 2
     assert all([orig_units[idx] == unit for idx in range(n_chans - 1)])
     assert orig_units[-1] == '°C'
+
+
+def test_cleanup(tmpdir):
+    """Test cleaning up intermediate data upon a writing failure."""
+    folder_out = tmpdir / "my_output"
+    with pytest.raises(ValueError, match="Data format binary_float999"):
+        write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
+                          fname_base=fname, folder_out=folder_out,
+                          fmt="binary_float999")
+    assert not op.exists(folder_out)
+    assert not op.exists(folder_out / fname + ".eeg")
+    assert not op.exists(folder_out / fname + ".vmrk")
+    assert not op.exists(folder_out / fname + ".vhdr")
+
+
+def test_overwrite(tmpdir):
+    """Test overwriting behavior."""
+    write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
+                      fname_base=fname, folder_out=tmpdir,
+                      overwrite=False)
+
+    with pytest.raises(IOError, match="File already exists"):
+        write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names,
+                          fname_base=fname, folder_out=tmpdir,
+                          overwrite=False)


### PR DESCRIPTION
closes #63 

- better file handling: Delete intermediate files when writing fails
- better input checks: raise error when ch_names is not list of str (or list of int which we can easily turn into str)
- add `overwrite` parameter and set new default (False) --> previously pybv *always* overwrote files, which was a bit dangerous IMHO

Also adds tests for all of those