### PR TITLE
Force little-endian format when writing eeg datafile

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,6 +23,9 @@ authors:
 - given-names: "Phillip"
   family-names: "Alday"
   orcid: https://orcid.org/0000-0002-9984-5745
+- given-names: "Aniket"
+  family-names: "Pradhan"
+  orcid: https://orcid.org/0000-0002-6705-5116
 title: "pybv"
 version: 0.5.0
 date-released: 2021-01-03

--- a/README.rst
+++ b/README.rst
@@ -61,10 +61,11 @@ consisting of:
 - key-value pairs marked as ``key=value``
 
 The binary ``.eeg`` data file is written in little-endian format without a Byte Order
-Mark (BOM). This ensures that the data file is uniformly written irrespective of the
+Mark (BOM), in accordance with the specification by Brain Products.
+This ensures that the data file is uniformly written irrespective of the
 native system architecture.
 
-A documentation for core BrainVision file format is provided by Brain Products.
+A documentation for the BrainVision file format is provided by Brain Products.
 You can `view the specification <https://www.brainproducts.com/productdetails.php?id=21&tab=5>`_
 as hosted by Brain Products.
 

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,10 @@ consisting of:
 - comments marked as ``; comment``
 - key-value pairs marked as ``key=value``
 
+The binary ``.eeg`` data file is written in little-endian format without a Byte Order
+Mark (BOM). This ensures that the data file is uniformly written irrespective of the
+native system architecture.
+
 A documentation for core BrainVision file format is provided by Brain Products.
 You can `view the specification <https://www.brainproducts.com/productdetails.php?id=21&tab=5>`_
 as hosted by Brain Products.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,7 +34,7 @@ Changelog
 ~~~~~~~~~
 
 - :func:`pybv.write_brainvision` gained a new parameter, ``ref_ch_names``, to specify the reference channels used during recording, by `Richard Höchenberger`_ and `Stefan Appelhoff`_ (:gh:`75`)
-- Fix bug where :func:`pybv.write_brainvision` would write the binary eeg file in big-endian on a big-endian system. This could lead to non-uniformity of data-files written by big-endian or little-endian machines, by `Aniket Pradhan`, `Clemens Brunner` and `Stefan Appelhoff`_ (:gh:`80`).
+- Fix bug where :func:`pybv.write_brainvision` would write the binary eeg file in big-endian on a big-endian system. This could lead to non-uniformity of data-files written by big-endian or little-endian machines, by `Aniket Pradhan`_, `Clemens Brunner`_ and `Stefan Appelhoff`_ (:gh:`80`).
 
 API
 ~~~
@@ -127,3 +127,4 @@ Changelog
 .. _Clemens Brunner: https://cbrnr.github.io/
 .. _Richard Höchenberger: https://hoechenberger.net/
 .. _Adam Li: https://adam2392.github.io/
+.. _Aniket Pradhan: http://home.iiitd.edu.in/~aniket17133/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Authors
 People who contributed to this software across releases (in **alphabetical order**):
 
 - `Adam Li`_
+- `Aniket Pradhan`_
 - `Chris Holdgraf`_
 - `Clemens Brunner`_
 - `Phillip Alday`_
@@ -33,6 +34,7 @@ Changelog
 ~~~~~~~~~
 
 - :func:`pybv.write_brainvision` gained a new parameter, ``ref_ch_names``, to specify the reference channels used during recording, by `Richard Höchenberger`_ and `Stefan Appelhoff`_ (:gh:`75`)
+- Fix bug where :func:`pybv.write_brainvision` would write the binary eeg file in big-endian on a big-endian system. This could lead to non-uniformity of data-files written by big-endian or little-endian machines, by `Aniket Pradhan`, `Clemens Brunner` and `Stefan Appelhoff`_ (:gh:`80`).
 
 API
 ~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,13 +32,15 @@ Current (unreleased)
 
 Changelog
 ~~~~~~~~~
-
 - :func:`pybv.write_brainvision` gained a new parameter, ``ref_ch_names``, to specify the reference channels used during recording, by `Richard Höchenberger`_ and `Stefan Appelhoff`_ (:gh:`75`)
-- Fix bug where :func:`pybv.write_brainvision` would write the binary file in big-endian on a big-endian system, by `Aniket Pradhan`_, `Clemens Brunner`_, and `Stefan Appelhoff`_ (:gh:`80`)
 
 API
 ~~~
 - :func:`pybv.write_brainvision` now has an ``overwrite`` parameter that defaults to ``False``, by `Stefan Appelhoff`_ (:gh:`78`).
+
+Bug
+~~~
+- Fix bug where :func:`pybv.write_brainvision` would write the binary file in big-endian on a big-endian system, by `Aniket Pradhan`_, `Clemens Brunner`_, and `Stefan Appelhoff`_ (:gh:`80`)
 
 0.5.0 (2021-01-03)
 ==================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,7 +34,7 @@ Changelog
 ~~~~~~~~~
 
 - :func:`pybv.write_brainvision` gained a new parameter, ``ref_ch_names``, to specify the reference channels used during recording, by `Richard Höchenberger`_ and `Stefan Appelhoff`_ (:gh:`75`)
-- Fix bug where :func:`pybv.write_brainvision` would write the binary eeg file in big-endian on a big-endian system. This could lead to non-uniformity of data-files written by big-endian or little-endian machines, by `Aniket Pradhan`_, `Clemens Brunner`_ and `Stefan Appelhoff`_ (:gh:`80`).
+- Fix bug where :func:`pybv.write_brainvision` would write the binary file in big-endian on a big-endian system, by `Aniket Pradhan`_, `Clemens Brunner`_, and `Stefan Appelhoff`_ (:gh:`80`)
 
 API
 ~~~

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -494,8 +494,8 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
 
     # Swap bytes if system architecure is big-endian and dtype is "native" or
     # "big-endian"
-    if ((sys.byteorder == "big" and data.dtype.byteorder == "=") or
-            data.dtype.byteorder == ">"):
+    byteorder = data.dtype.byteorder
+    if (sys.byteorder == "big" and byteorder == "=") or byteorder == ">":
         data = data.byteswap()
 
     # Save to binary

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -492,11 +492,13 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
         raise ValueError(msg)
     data = data.astype(dtype=dtype)
 
-    # Swap bytes if system architecture is big-endian and dtype is "native" or
-    # "big-endian"
-    byteorder = data.dtype.byteorder
-    if ((sys.byteorder == "big" and byteorder == "=") or
-            byteorder == ">"):  # pragma: no cover
+    # We always write data as little-endian without BOM
+    # `data` is already in native byte order due to numpy operations that
+    # result in copies of the `data` array (see above)
+    assert data.dtype.byteorder == "="
+
+    # swap bytes if system architecture is big-endian
+    if sys.byteorder == "big":  # pragma: no cover
         data = data.byteswap()
 
     # Save to binary

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -494,8 +494,8 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
 
     # Swap bytes if system architecure is big-endian and dtype is "native" or
     # "big-endian"
-    if (sys.byteorder == "big" and
-       (data.dtype.byteorder == "=" or data.dtype.byteorder == ">")):
+    if ((sys.byteorder == "big" and data.dtype.byteorder == "=") or
+            data.dtype.byteorder == ">"):
         data = data.byteswap()
 
     # Save to binary

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -494,8 +494,8 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
 
     # Swap bytes if system architecure is big-endian and dtype is "native" or
     # "big-endian"
-    byteorder = data.dtype.byteorder  # pragma: no cover
-    if (sys.byteorder == "big" and byteorder == "=") or byteorder == ">":  # pragma: no cover  # noqa: E501
+    byteorder = data.dtype.byteorder
+    if (sys.byteorder == "big" and byteorder == "=") or byteorder == ">":  # pragma: no cover noqa: E501
         data = data.byteswap()
 
     # Save to binary

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -495,7 +495,8 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
     # Swap bytes if system architecure is big-endian and dtype is "native" or
     # "big-endian"
     byteorder = data.dtype.byteorder
-    if (sys.byteorder == "big" and byteorder == "=") or byteorder == ">":  # pragma: no cover noqa: E501
+    if ((sys.byteorder == "big" and byteorder == "=") or
+            byteorder == ">"):  # pragma: no cover
         data = data.byteswap()
 
     # Save to binary

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -492,7 +492,7 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
         raise ValueError(msg)
     data = data.astype(dtype=dtype)
 
-    # Swap bytes if system architecure is big-endian and dtype is "native" or
+    # Swap bytes if system architecture is big-endian and dtype is "native" or
     # "big-endian"
     byteorder = data.dtype.byteorder
     if ((sys.byteorder == "big" and byteorder == "=") or

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -14,6 +14,7 @@
 import datetime
 import os
 import shutil
+import sys
 from os import path as op
 from warnings import warn
 
@@ -490,6 +491,12 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
             msg += "\nPlease consider writing using 'binary_float32' format."
         raise ValueError(msg)
     data = data.astype(dtype=dtype)
+
+    # Swap bytes if system architecure is big-endian and dtype is "native" or
+    # "big-endian"
+    if (sys.byteorder == "big" and
+       (data.dtype.byteorder == "=" or data.dtype.byteorder == ">")):
+        data = data.byteswap()
 
     # Save to binary
     data.ravel(order='F').tofile(eeg_fname)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -494,8 +494,8 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units):
 
     # Swap bytes if system architecure is big-endian and dtype is "native" or
     # "big-endian"
-    byteorder = data.dtype.byteorder
-    if (sys.byteorder == "big" and byteorder == "=") or byteorder == ">":
+    byteorder = data.dtype.byteorder  # pragma: no cover
+    if (sys.byteorder == "big" and byteorder == "=") or byteorder == ">":  # pragma: no cover  # noqa: E501
         data = data.byteswap()
 
     # Save to binary


### PR DESCRIPTION
Also updated the docs to add information about this change 😸 

closes #79 