### PR TITLE
MAINT: Clean up warnings raised by tests

### DIFF
--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -345,14 +345,10 @@ def test_write_multiple_units(tmpdir, unit):
     units = [unit] * (n_chans // 2)
     units.extend([other_unit] * (n_chans // 2))
 
-    # write file and read back in
-    expect_warn = True
+    # write file and read back in, we always expect a warning here
     kwargs["unit"] = units
     kwargs["overwrite"] = True
-    if expect_warn:
-        with pytest.warns(UserWarning, match="unsupported"):
-            write_brainvision(**kwargs)
-    else:
+    with pytest.warns(UserWarning, match="unsupported"):
         write_brainvision(**kwargs)
 
     raw_written = mne.io.read_raw_brainvision(vhdr_fname=vhdr_fname,


### PR DESCRIPTION
- ignoring some expected warnings (ref #64 )
- catch some other expected warnings

Overall, having looked at the `test_format_resolution_unit` test in more detail now, I think we can close #64. I think the test is quite clear and covers all cases.

PS: The test suite raises 2 warnings still. These come from the doctests, and I don't know how to silence them: https://github.com/bids-standard/pybv/blob/ee1c78927768c939518d583b955eef0bb504f925/pybv/io.py#L129-L143

PPS: The formatting issue is fixed in #81. I'll rebase this PR on `main` after #81 is merged.