### PR TITLE
Allow passing list of dict as argument to events parameter (=allow writing mne.annotations to VMRK)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE
 include requirements-dev.txt
 include CITATION.cff
 include .mailmap
+include .flake8
 
 graft docs
 graft pybv

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ Current (unreleased)
 Changelog
 ~~~~~~~~~
 - Added an overview table of alternative software for BrainVision data, by `Stefan Appelhoff`_: (:gh:`85`)
+- :func:`pybv.write_brainvision` now accepts a list of dict as argument to the ``events`` parameter, allowing for more control over what to write to ``.vmrk``, by `Stefan Appelhoff`_: (:gh:`86`)
 
 0.6.0 (2021-09-29)
 ==================
@@ -54,7 +55,7 @@ Bug
 
 Changelog
 ~~~~~~~~~
-- :func:`pybv.write_brainvision` adds support for channels with non-Volt units, by `Adam Li`_ (:gh:`66`)
+- :func:`pybv.write_brainvision` adds support for channels with non-volt units, by `Adam Li`_ (:gh:`66`)
 - :func:`pybv.write_brainvision` automatically converts ``uV`` and ``μV`` (Greek μ) to ``µV`` (micro sign µ), by `Adam Li`_ (:gh:`66`)
 
 API

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -379,13 +379,13 @@ def _chk_events(events, ch_names, n_times):
         del _events
 
     # validate input: list of dict
-    for iev, event in enumerate(events):
-
+    for event in events:
         # each item must be dict
         if not isinstance(event, dict):
             raise ValueError("When list, events must be a list of dict, but found "
                              "non-dict element in list")
 
+    for iev, event in enumerate(events):
         # required keys
         for required_key in ["onset", "description"]:
             if required_key not in event:
@@ -434,7 +434,9 @@ def _chk_events(events, ch_names, n_times):
             # NOTE: We format 1 -> "S  1", 10 -> "S 10", 100 -> "S100", etc.,
             # https://github.com/bids-standard/pybv/issues/24#issuecomment-512746677
             if iev == 0:
-                max_event_descr = max([event["description"] for event in events])
+                max_event_descr = max([1] + [ev["description"]
+                                      for ev in events
+                                      if isinstance(ev["description"], int)])
             twidth = int(np.ceil(np.log10(max_event_descr)))
             twidth = max(3, twidth)
             tformat = event["type"][0] + '{:>' + str(twidth) + '}'

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -39,9 +39,9 @@ def write_brainvision(*, data, sfreq, ch_names,
     Parameters
     ----------
     data : np.ndarray, shape (n_channels, n_times)
-        The raw data to export. Voltage data is assumed to be in **Volts** and
+        The raw data to export. Voltage data is assumed to be in **volts** and
         will be scaled as specified by `unit`. Non-voltage channels (as
-        specified by `unit`) are never scaled (e.g. '°C').
+        specified by `unit`) are never scaled (e.g. "°C").
     sfreq : int | float
         The sampling frequency of the data in Hz.
     ch_names : list of {str | int}, len (n_channels)
@@ -69,13 +69,13 @@ def write_brainvision(*, data, sfreq, ch_names,
         (not writing any events).
 
         If an array is passed, it must have either two or three columns and
-        consist of positive integer values. The first column is always the
-        zero-based "onset" index of each event (corresponding to the
-        "time" dimension of the `data` array). The second column is a number
-        associated with the "description" of the event. The (optional) third
-        column specifies the "duration" of each event in samples (default
-        1 sample). All events are written as type "Stimulus" and interpreted
-        as relevant to all channels. For more fine grained control over how to
+        consist of positive int values. The first column is always the
+        zero-based *onset* index of each event (corresponding to the
+        time dimension of the `data` array). The second column is a number
+        associated with the *description* of the event. The (optional) third
+        column specifies the *duration* of each event in samples (defaults to
+        ``1``). All events are written as *type* "Stimulus" and interpreted
+        as relevant to all *channels*. For more fine grained control over how to
         write events, pass a list of dict as described next.
 
         If list of dict is passed, each dict in the list corresponds to an
@@ -83,18 +83,18 @@ def write_brainvision(*, data, sfreq, ch_names,
 
             - ``onset`` : int
                 The zero-based index of the event onset, corresponding to the
-                "time" dimension of the `data` array.
+                time dimension of the `data` array.
             - ``duration`` : int
                 The duration of the event in samples (defaults to ``1``).
             - ``description`` : str | int
-                The description of the event. Must be a positive integer when
+                The description of the event. Must be a positive int when
                 `type` (see below) is either "Stimulus" or "Response", and may
-                be a string when `type` is "Comment".
+                be a str when `type` is "Comment".
             - ``type`` : str
-                The type of the event, must be one of {"Stimulus", "Comment",
-                "Response"} (defaults to ``"Stimulus"``). The following
-                known BrainVision "types" are currently **not** supported:
-                "New Segment", "SyncStatus".
+                The type of the event, must be one of {"Stimulus", "Response",
+                "Comment"} (defaults to ``"Stimulus"``). Additional types like
+                the known BrainVision types "New Segment", "SyncStatus", etc.
+                are currently not supported.
             - ``channels`` : str | list of {str | int}
                 The channels that are impacted by the event. Can be "all"
                 (reflecting all channels) or a channel name, or a list of
@@ -117,38 +117,43 @@ def write_brainvision(*, data, sfreq, ch_names,
         n_channels elements, each channel is scaled with its own corresponding
         resolution from the array. Note that `resolution` is applied on top
         of the default resolution that a data format (see `fmt`) has. For
-        example, the 'binary_int16' format by design has no floating point
+        example, the "binary_int16" format by design has no floating point
         support, but when scaling the data in µV for 0.1 resolution (default),
         accurate writing for all values >= 0.1 µV is guaranteed. In contrast,
-        the 'binary_float32' format by design already supports floating points
-        up to 1e-6 resolution, and writing data in 'µV' with 0.1 resolution
-        will thus guarantee accurate writing for all values >= 1e-7 'µV'
+        the "binary_float32" format by design already supports floating points
+        up to 1e-6 resolution, and writing data in "µV" with 0.1 resolution
+        will thus guarantee accurate writing for all values >= 1e-7 "µV"
         (``1e-6 * 0.1``).
     unit : str | list of str
-        The unit of the exported data. This can be one of 'V', 'mV', 'µV' (or
-        equivalently 'uV') , or 'nV', which will scale the data accordingly.
-        Defaults to ``'µV'``. Can also be a list of units with one unit per
+        The unit of the exported data. This can be one of "V", "mV", "µV" (or
+        equivalently "uV") , or "nV", which will scale the data accordingly.
+        Defaults to ``"µV"``. Can also be a list of units with one unit per
         channel. Non-voltage channels are stored as is, for example
-        temperature might be available in '°C', which ``pybv`` will not scale.
+        temperature might be available in "°C", which ``pybv`` will not scale.
     fmt : str
         Binary format the data should be written as. Valid choices are
-        'binary_float32' (default) and 'binary_int16'.
+        "binary_float32" (default) and "binary_int16".
     meas_date : datetime.datetime | str | None
         The measurement date specified as a :class:`datetime.datetime` object.
-        Alternatively, can be a str in the format 'YYYYMMDDhhmmssuuuuuu'
-        ('u' stands for microseconds). Note that setting a measurement date
+        Alternatively, can be a str in the format "YYYYMMDDhhmmssuuuuuu"
+        ("u" stands for microseconds). Note that setting a measurement date
         implies that one additional event is created in the *.vmrk* file. To
         prevent this, set this parameter to ``None`` (default).
 
     Notes
     -----
-    iEEG/EEG/MEG data is assumed to be in 'V', and we will scale these data to
-    'µV' by default. Any unit besides 'µV' is officially unsupported in the
+    iEEG/EEG/MEG data is assumed to be in "V", and ``pybv`` will scale these data
+    to "µV" by default. Any unit besides "µV" is officially unsupported in the
     BrainVision specification. However, if one specifies other voltage units
-    such as 'mV' or 'nV', we will still scale the signals accordingly in the
+    such as "mV" or "nV", we will still scale the signals accordingly in the
     exported file. We will also write channels with non-voltage units such as
-    '°C' as is (without scaling). For maximum compatibility, all signals
-    should be written as 'µV'.
+    "°C" as is (without scaling). For maximum compatibility, all signals
+    should be written as "µV".
+
+    When passing a list of dict to `events`, the event ``type`` that can be passed
+    is currently limited to one of {"Stimulus", "Response", "Comment"}. The
+    BrainVision specification itself does not limit event types, and future
+    extensions of ``pybv`` may permit additional or even arbitrary event types.
 
     References
     ----------
@@ -162,13 +167,13 @@ def write_brainvision(*, data, sfreq, ch_names,
     ... # rescaled to µV and mV respectively.
     ... # TEMP is expected to be in some other unit (i.e., NOT Volt), and
     ... # will not get scaled (it is "written as is")
-    ... write_brainvision(data=data, sfreq=1, ch_names=['A1', 'A2', 'TEMP'],
-    ...                   folder_out='./',
-    ...                   fname_base='pybv_test_file',
-    ...                   unit=['µV', 'mV', '°C'])
+    ... write_brainvision(data=data, sfreq=1, ch_names=["A1", "A2", "TEMP"],
+    ...                   folder_out="./",
+    ...                   fname_base="pybv_test_file",
+    ...                   unit=["µV", "mV", "°C"])
     >>> # remove the files
-    >>> for ext in ['.vhdr', '.vmrk', '.eeg']:
-    ...     os.remove('pybv_test_file' + ext)
+    >>> for ext in [".vhdr", ".vmrk", ".eeg"]:
+    ...     os.remove("pybv_test_file" + ext)
     """  # noqa: E501
     # Input checks
     if not isinstance(data, np.ndarray):

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -379,7 +379,7 @@ def _chk_events(events, ch_names, n_times):
         del _events
 
     # validate input: list of dict
-    for event in list:
+    for event in events:
 
         # each item must be dict
         if not isinstance(event, dict):

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -473,6 +473,12 @@ def _chk_events(events, ch_names, n_times):
                  "than one but less than all channels in the data. This "
                  "feature may not be supported by all BrainVision readers.")
 
+        # convert channels to indices (1-based, 0="all")
+        ch_idxs = [ch_names.index(ch) + 1 for ch in event["channels"]]
+        if set(ch_idxs) == {i + 1 for i in range(len(ch_names))}:
+            ch_idxs = [0]
+        event["channels"] = sorted(ch_idxs)
+
     return events
 
 

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -412,7 +412,7 @@ def _chk_events(events, ch_names, n_times):
                              f"data (0-{n_times-1})")
 
         if event["duration"] < 1:
-            raise ValueError("events: at least one duration is negative. Durations "
+            raise ValueError("events: at least one duration is too short. Durations "
                              "must be >= 1 sample.")
 
         if not (0 <= event["onset"] + event["duration"] < n_times):
@@ -430,7 +430,7 @@ def _chk_events(events, ch_names, n_times):
         if event["type"] in ["Stimulus", "Response"]:
             if not isinstance(event["description"], int):
                 raise ValueError(f"events: when `type` is {event['type']}, "
-                                 "`description` must be int")
+                                 "`description` must be positive int")
 
             if event["description"] < 1:
                 raise ValueError(f"events: when `type` is {event['type']}, "

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -76,7 +76,7 @@ def write_brainvision(*, data, sfreq, ch_names,
         associated with the *description* of the event. The (optional) third
         column specifies the *duration* of each event in samples (defaults to
         ``1``). All events are written as *type* "Stimulus" and interpreted
-        as relevant to all *channels*. For more fine grained control over how to
+        as relevant to all *channels*. For more fine-grained control over how to
         write events, pass a list of dict as described next.
 
         If list of dict is passed, each dict in the list corresponds to an
@@ -324,8 +324,8 @@ def _chk_events(events, ch_names, n_times):
     """Check that the events parameter is as expected.
 
     This function will always return `events` as a list of dicts.
-    If `events` was ``None``, it will be an empty list.
-    If `events` was a list of dict, it will add missing keys to each dict with
+    If `events` is ``None``, it will be an empty list.
+    If `events` is a list of dict, it will add missing keys to each dict with
     default values, and it will turn events[i]["channels"] into a list of
     1-based channel name indices, where 0 = "all". Event descriptions for
     "Stimulus" and "Response" will be reformatted to the "Sxxx" or "Rxxx"

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -42,11 +42,11 @@ def write_brainvision(*, data, sfreq, ch_names,
     data : np.ndarray, shape (n_channels, n_times)
         The raw data to export. Voltage data is assumed to be in **volts** and
         will be scaled as specified by `unit`. Non-voltage channels (as
-        specified by `unit`) are never scaled (e.g. "°C").
+        specified by `unit`) are never scaled (e.g., `"°C"`).
     sfreq : int | float
         The sampling frequency of the data in Hz.
     ch_names : list of {str | int}, len (n_channels)
-        The names of the channels.
+        The names of the channels. Integer channel names are converted to string.
     ref_ch_names : str | list of str, len (n_channels) | None
         The name of the channel used as a reference during the recording. If
         references differed between channels, you may supply a list of
@@ -70,7 +70,7 @@ def write_brainvision(*, data, sfreq, ch_names,
         (not writing any events).
 
         If an array is passed, it must have either two or three columns and
-        consist of positive int values. The first column is always the
+        consist of nonnegative integers. The first column is always the
         zero-based *onset* index of each event (corresponding to the
         time dimension of the `data` array). The second column is a number
         associated with the *description* of the event. The (optional) third
@@ -82,24 +82,26 @@ def write_brainvision(*, data, sfreq, ch_names,
         If list of dict is passed, each dict in the list corresponds to an
         event and may have the following entries:
 
-            - ``onset`` : int
+            - ``"onset"`` : int
                 The zero-based index of the event onset, corresponding to the
                 time dimension of the `data` array.
-            - ``duration`` : int
+            - ``"duration"`` : int
                 The duration of the event in samples (defaults to ``1``).
-            - ``description`` : str | int
+            - ``"description"`` : str | int
                 The description of the event. Must be a positive int when
-                `type` (see below) is either "Stimulus" or "Response", and may
-                be a str when `type` is "Comment".
-            - ``type`` : str
-                The type of the event, must be one of {"Stimulus", "Response",
-                "Comment"} (defaults to ``"Stimulus"``). Additional types like
-                the known BrainVision types "New Segment", "SyncStatus", etc.
+                `type` (see below) is either ``"Stimulus"`` or ``"Response"``, and may
+                be a str when `type` is ``"Comment"``.
+            - ``"type"`` : str
+                The type of the event, must be one of ``{"Stimulus", "Response",
+                "Comment"}`` (defaults to ``"Stimulus"``). Additional types like
+                the known BrainVision types ``"New Segment"``, ``"SyncStatus"``, etc.
                 are currently not supported.
-            - ``channels`` : str | list of {str | int}
-                The channels that are impacted by the event. Can be "all"
-                (reflecting all channels) or a channel name, or a list of
-                channel names. Defaults to ``"all"``.
+            - ``"channels"`` : str | list of {str | int}
+                The channels that are impacted by the event. Can be ``"all"``
+                (reflecting all channels), or a channel name, or a list of
+                channel names. An empty list means the same as ``"all"``.
+                Integer channel names are converted to strings, as in the
+                `ch_names` parameter. Defaults to ``"all"``.
 
         Note that ``onset`` and ``description`` MUST be specified in each
         dict.
@@ -118,22 +120,22 @@ def write_brainvision(*, data, sfreq, ch_names,
         n_channels elements, each channel is scaled with its own corresponding
         resolution from the array. Note that `resolution` is applied on top
         of the default resolution that a data format (see `fmt`) has. For
-        example, the "binary_int16" format by design has no floating point
-        support, but when scaling the data in µV for 0.1 resolution (default),
+        example, the ``"binary_int16"`` format by design has no floating point
+        support, but when scaling the data in µV for ``0.1`` resolution (default),
         accurate writing for all values >= 0.1 µV is guaranteed. In contrast,
-        the "binary_float32" format by design already supports floating points
-        up to 1e-6 resolution, and writing data in "µV" with 0.1 resolution
-        will thus guarantee accurate writing for all values >= 1e-7 "µV"
+        the ``"binary_float32"`` format by design already supports floating points
+        up to 1e-6 resolution, and writing data in µV with 0.1 resolution
+        will thus guarantee accurate writing for all values >= 1e-7 µV
         (``1e-6 * 0.1``).
     unit : str | list of str
-        The unit of the exported data. This can be one of "V", "mV", "µV" (or
-        equivalently "uV") , or "nV", which will scale the data accordingly.
-        Defaults to ``"µV"``. Can also be a list of units with one unit per
-        channel. Non-voltage channels are stored as is, for example
-        temperature might be available in "°C", which ``pybv`` will not scale.
+        The unit of the exported data. This can be one of ``"V"``, ``"mV"``, ``"µV"``
+        (or equivalently ``"uV"``) , or ``"nV"``, which will scale the data
+        accordingly. Defaults to ``"µV"``. Can also be a list of units with one unit
+        per channel. Non-voltage channels are stored "as is", for example
+        temperature might be available in ``"°C"``, which ``pybv`` will not scale.
     fmt : str
         Binary format the data should be written as. Valid choices are
-        "binary_float32" (default) and "binary_int16".
+        ``"binary_float32"`` (default) and ``"binary_int16"``.
     meas_date : datetime.datetime | str | None
         The measurement date specified as a :class:`datetime.datetime` object.
         Alternatively, can be a str in the format "YYYYMMDDhhmmssuuuuuu"
@@ -143,16 +145,16 @@ def write_brainvision(*, data, sfreq, ch_names,
 
     Notes
     -----
-    iEEG/EEG/MEG data is assumed to be in "V", and ``pybv`` will scale these data
-    to "µV" by default. Any unit besides "µV" is officially unsupported in the
+    iEEG/EEG/MEG data is assumed to be in V, and ``pybv`` will scale these data
+    to µV by default. Any unit besides µV is officially unsupported in the
     BrainVision specification. However, if one specifies other voltage units
-    such as "mV" or "nV", we will still scale the signals accordingly in the
+    such as mV or nV, we will still scale the signals accordingly in the
     exported file. We will also write channels with non-voltage units such as
-    "°C" as is (without scaling). For maximum compatibility, all signals
-    should be written as "µV".
+    °C as is (without scaling). For maximum compatibility, all signals
+    should be written as µV.
 
     When passing a list of dict to `events`, the event ``type`` that can be passed
-    is currently limited to one of {"Stimulus", "Response", "Comment"}. The
+    is currently limited to one of ``{"Stimulus", "Response", "Comment"}``. The
     BrainVision specification itself does not limit event types, and future
     extensions of ``pybv`` may permit additional or even arbitrary event types.
 
@@ -164,10 +166,10 @@ def write_brainvision(*, data, sfreq, ch_names,
     --------
     >>> data = np.random.random((3, 5))
     >>> # write data with varying units
-    ... # Note channels A1 and A2 are expected to be in Volt and will get
+    ... # Note channels A1 and A2 are expected to be in volt and will get
     ... # rescaled to µV and mV respectively.
-    ... # TEMP is expected to be in some other unit (i.e., NOT Volt), and
-    ... # will not get scaled (it is "written as is")
+    ... # TEMP is expected to be in some other unit (i.e., NOT volt), and
+    ... # will not get scaled (it is written "as is")
     ... write_brainvision(data=data, sfreq=1, ch_names=["A1", "A2", "TEMP"],
     ...                   folder_out="./",
     ...                   fname_base="pybv_test_file",
@@ -175,13 +177,14 @@ def write_brainvision(*, data, sfreq, ch_names,
     >>> # remove the files
     >>> for ext in [".vhdr", ".vmrk", ".eeg"]:
     ...     os.remove("pybv_test_file" + ext)
-    """  # noqa: E501
+    """
     # Input checks
     if not isinstance(data, np.ndarray):
         raise ValueError(f"data must be np.ndarray, but found: {type(data)}")
 
     if not data.ndim == 2:
-        raise ValueError("data must be 2D: shape (n_channels, n_times)")
+        raise ValueError("data must be 2D: shape (n_channels, n_times), "
+                         f"but found {data.ndim}")
 
     if not isinstance(overwrite, bool):
         raise ValueError("overwrite must be a boolean (True or False).")
@@ -326,11 +329,13 @@ def _chk_events(events, ch_names, n_times):
     This function will always return `events` as a list of dicts.
     If `events` is ``None``, it will be an empty list.
     If `events` is a list of dict, it will add missing keys to each dict with
-    default values, and it will turn events[i]["channels"] into a list of
-    1-based channel name indices, where 0 = "all". Event descriptions for
-    "Stimulus" and "Response" will be reformatted to the "Sxxx" or "Rxxx"
-    format. Each events[i]["onset"] will be incremented by 1 for 1-based
-    indexing used in VMRK.
+    default values, and it will -- for each ith event -- turn ``events[i]["channels"]``
+    into a list of 1-based channel name indices, where ``0`` equals ``"all"``.
+    Event descriptions for ``"Stimulus"`` and ``"Response"`` will be reformatted to
+    a str of the format ``"S{:>n}"`` (or with a leading ``"R"`` for ``"Response"``),
+    where ``n`` is determined by the description with the most digits (minimum 3).
+    For each ith event, the onset (``events[i]["onset"]``) will be incremented by 1
+    to comply with the 1-based indexing used in BrainVision marker files (*.vmrk*).
 
     Parameters
     ----------
@@ -345,7 +350,7 @@ def _chk_events(events, ch_names, n_times):
     -------
     events_out : list of dict, len (n_events)
         The preprocessed events, always provided as list of dict.
-    """  # noqa: E501
+    """
     if not isinstance(events, (type(None), np.ndarray, list)):
         raise ValueError("events must be an array, a list of dict, or None")
 
@@ -355,8 +360,7 @@ def _chk_events(events, ch_names, n_times):
 
     # default events
     # NOTE: using "ch_names" as default for channels translates directly
-    #       into "all" but is robust with respect to channels named
-    #       "all"
+    #       into "all" but is robust with respect to channels named "all"
     event_defaults = dict(duration=1, type="Stimulus", channels=ch_names)
 
     # validate input: ndarray
@@ -446,8 +450,7 @@ def _chk_events(events, ch_names, n_times):
                 max_event_descr = max([1] + [ev["description"]
                                       for ev in events_out
                                       if isinstance(ev["description"], int)])
-            twidth = int(np.ceil(np.log10(max_event_descr)))
-            twidth = max(3, twidth)
+            twidth = max(3, int(np.ceil(np.log10(max_event_descr))))
             tformat = event["type"][0] + '{:>' + str(twidth) + '}'
             event["description"] = tformat.format(event["description"])
 
@@ -469,10 +472,10 @@ def _chk_events(events, ch_names, n_times):
                 if "all" in ch_names:
                     raise ValueError(
                         "Found channel named 'all'. Your `channels` specification in "
-                        "events is also 'all': This is ambiguous, because 'all' is a "
+                        "events is also 'all'. This is ambiguous, because 'all' is a "
                         "reserved keyword. Either rename the channel called 'all', "
                         "or explicitly list all ch_names in `channels` in each event "
-                        "instead of using 'all'")
+                        "instead of using 'all'.")
                 event["channels"] = ch_names
             else:
                 event["channels"] = [event["channels"]]
@@ -561,7 +564,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
 def _scale_data_to_unit(data, units):
     """Scale `data` in Volts to `data` in `units`."""
     # only µV is supported by the BrainVision specs, but we support additional
-    # voltage prefixes (e.g. V, mV, nV); if such voltage units are used, we
+    # voltage prefixes (e.g., V, mV, nV); if such voltage units are used, we
     # issue a warning
     voltage_units = set()
 

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -365,21 +365,21 @@ def _chk_events(events, ch_names, n_times):
                              "found other types")
 
         # convert array to list of dict
-        durations = np.ones(events.shape[0]) * event_defaults["duration"]
+        durations = np.ones(events.shape[0], dtype=int) * event_defaults["duration"]
         if events.ndim == 3:
             durations = events[:, -1]
         _events = []
         for irow, row in enumerate(events[:, 0:2]):
-            _events.append(dict(onset=row[0],
-                                duration=durations[irow],
-                                description=row[1],
+            _events.append(dict(onset=int(row[0]),
+                                duration=int(durations[irow]),
+                                description=int(row[1]),
                                 type=event_defaults["type"],
                                 channels=event_defaults["channels"]))
         events = _events
         del _events
 
     # validate input: list of dict
-    for event in events:
+    for iev, event in enumerate(events):
 
         # each item must be dict
         if not isinstance(event, dict):
@@ -433,7 +433,8 @@ def _chk_events(events, ch_names, n_times):
 
             # NOTE: We format 1 -> "S  1", 10 -> "S 10", 100 -> "S100", etc.,
             # https://github.com/bids-standard/pybv/issues/24#issuecomment-512746677
-            max_event_descr = max([event["description"] for event in events])
+            if iev == 0:
+                max_event_descr = max([event["description"] for event in events])
             twidth = int(np.ceil(np.log10(max_event_descr)))
             twidth = max(3, twidth)
             tformat = event["type"][0] + '{:>' + str(twidth) + '}'

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -366,7 +366,7 @@ def _chk_events(events, ch_names, n_times):
 
         # convert array to list of dict
         durations = np.ones(events.shape[0], dtype=int) * event_defaults["duration"]
-        if events.ndim == 3:
+        if events.shape[1] == 3:
             durations = events[:, -1]
         _events = []
         for irow, row in enumerate(events[:, 0:2]):

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -497,8 +497,10 @@ def _chk_events(events, ch_names, n_times):
         # (experimental feature)
         if len(event["channels"]) > 1 and len(event["channels"]) < len(ch_names):
             warn("events: you specified at least one event that impacts more "
-                 "than one but less than all channels in the data. This "
-                 "feature may not be supported by all BrainVision readers.")
+                 "than one but less than all channels in the data. "
+                 "Such events will be written to .vmrk for as many times as "
+                 "channels are specified.\n\n"
+                 "This feature may not be supported by all BrainVision readers.")
 
         # convert channels to indices (1-based, 0="all")
         ch_idxs = [ch_names.index(ch) + 1 for ch in event["channels"]]

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -24,7 +24,7 @@ sfreq = 1000
 n_seconds = 5
 n_times = n_seconds * sfreq
 event_times = np.arange(1, 5)
-events = np.column_stack([event_times * sfreq, [1, 1, 2, 2]])
+events = np.column_stack([event_times * sfreq, [1, 1, 2, 2]]).astype(int)
 # scale random data to reasonable EEG signal magnitude in V
 data = rng.normal(size=(n_chans, n_times)) * 10 * 1e-6
 
@@ -35,12 +35,13 @@ data[-1, :] = 0.
 
 @pytest.mark.parametrize(
     "events_errormsg",
-    [([], 'events must be an ndarray of shape'),
-     (rng.normal(size=(10, 20, 30)), 'events must be an ndarray of shape'),
-     (rng.normal(size=(10, 4)), 'events must be an ndarray of shape'),
-     (np.array([i for i in "abcd"]).reshape(2, -1), 'events must be an ndarray of shape'),  # noqa: E501
+    [({}, 'events must be an array, a list of dict, or None'),
+     (rng.normal(size=(10, 20, 30)), 'When array, events must be 2D, but got 3'),
+     (rng.normal(size=(10, 4)), 'When array, events must have 2 or 3 columns, but got: 4'),  # noqa: E501
+     (np.array([i for i in "abcd"]).reshape(2, -1), 'When array, all entries in events must be int'),  # noqa: E501
      (events, ''),
-     (None, '')
+     (None, ''),
+     ([], ''),
      ])
 def test_bv_writer_events(tmpdir, events_errormsg):
     """Test that all event options work without throwing an error."""

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -95,7 +95,7 @@ def test_bv_writer_events_array(tmpdir, events_errormsg):
      ([{"onset": 1, "description": 1, "channels": 1}], "events: `channels` must be str or list of str"),  # noqa: E501
      ([{"onset": 1, "description": 1, "channels": [{}]}], "be list of str or list of int corresponding to ch_names"),  # noqa: E501
      ([], ''),
-     (events, ''),
+     (events, 'warn___you specified at least one event that impacts more than one'),
      ])
 def test_bv_writer_events_list_of_dict(tmpdir, events_errormsg):
     """Test that events are written properly when list of dict."""

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -75,7 +75,7 @@ def test_bv_writer_events_array(tmpdir, events_errormsg):
 @pytest.mark.parametrize(
     "events_errormsg",
     [([{}, {"onset": 1}], "must have the keys 'onset' and 'description'"),
-     ([{"onset": 1, "description": 2}, 12], "When list, events must be a list of dict"),
+     ([{"onset": 1, "description": 2}, np.ones(12)], "events must be a list of dict"),
      ([{"onset": "1", "description": 2}], "events: `onset` must be int"),
      ([{"onset": -1, "description": 2}], r"events: at least one onset sample is not in range of data \(0-4999\)"),  # noqa: E501
      ([{"onset": 100, "description": 1, "duration": 0}], "events: at least one duration is too short."),  # noqa: E501


### PR DESCRIPTION
closes #77 

this is what's needed to make pybv a "writer" in the MNE-Python export module.

It will allow writing more detailed events to VMRK (everything 100% in line with the spec).
Specifically we will support:

- writing event types other than "Stimulus" --> for now I added "Stimulus", "Response", and "Comment"
    - "Comment" is special because it will allow any string as a "description", instead of positive ints as previously required for Stimulus
- writing events pertaining to specific channels

One caveat is, that **in principle** the BrainVision format does not restrict the event type to "Stimulus", "Response", "Comment. --> in fact, one could have **any** type, see https://github.com/bids-standard/pybv/issues/24#issuecomment-514324063

Yet in practice, we most often see:

- Stimulus
- Response
- Comment
- New Segment
- SyncStatus

Here I implement Stimulus and Response as previously for only Stimulus --> writing integer code "event descriptions".

Comment can then be used for free form strings ... I think this suffices for now and we can see whether users will need additional stuff in the future. Let's go step by step.

- [x] add tests
- [x] docstr documentation
- [x] unify API to "under the hood" always use list of dict
