### PR TITLE
Add private function for mne export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ inplace:
 	@python setup.py develop
 
 test:
-	@echo "Running pytest"
-	@pytest --doctest-modules --cov=./pybv --cov-report=xml --verbose
+	@echo "Running pytest: doctests"
+	@pytest pybv/io.py --doctest-modules -W ignore::UserWarning --verbose
+	@echo "Running pytest: test modules"
+	@pytest --cov=./pybv --cov-report=xml --verbose
 
 flake:
 	@echo "Running flake8"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,6 @@ html_sidebars = {
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'mne': ('https://mne.tools/dev/', None),
-    'numpy': ('https://www.numpy.org/devdocs', None),
+    'numpy': ('https://numpy.org/devdocs', None),
 }
 intersphinx_timeout = 10

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ html_sidebars = {
 # When functions from other packages are mentioned, link to them
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'mne': ('http://mne.tools/dev/', None),
+    'mne': ('https://mne.tools/dev/', None),
     'numpy': ('https://www.numpy.org/devdocs', None),
 }
-intersphinx_timeout = 5
+intersphinx_timeout = 10

--- a/pybv/_export.py
+++ b/pybv/_export.py
@@ -133,8 +133,8 @@ def _mne_annots2pybv_events(raw):
         # Add a "pybv" event
         events += [
             dict(
-                onset=onset,
-                duration=duration,
+                onset=onset,  # in samples
+                duration=duration,  # in samples
                 description=description,
                 type=etype,
                 channels=channels,

--- a/pybv/_export.py
+++ b/pybv/_export.py
@@ -1,0 +1,29 @@
+"""Use pybv to export data from different software packages to BrainVision."""
+
+from pathlib import Path
+
+from pybv import write_brainvision
+
+
+def _export_mne_raw(*, raw, fname, overwrite=False):
+    """Export raw data from MNE-Python.
+
+    Parameters
+    ----------
+    raw : mne.io.Raw
+        The raw data to export.
+    fname : str
+        The name of the file where raw data will be exported to. Must end with ".vhdr",
+        and accompanying ".vmrk" and ".eeg" files will be written inside the same
+        directory.
+    overwrite: bool
+        Whether or not to overwrite existing data. Default to False
+    """
+    data = raw.get_data()
+    sfreq = raw.info["sfreq"]
+    ch_names = raw.ch_names
+    fname = Path(fname)
+    folder_out = fname.parents()[0]
+    fname_base = fname.name
+    write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names, fname_base=fname_base,
+                      folder_out=folder_out, overwrite=overwrite)

--- a/pybv/_export.py
+++ b/pybv/_export.py
@@ -108,7 +108,7 @@ def _mne_annots2pybv_events(raw):
 
         # Handle onset and duration: seconds to sample,
         # relative to raw.first_samp
-        onset = raw.time_as_index(annot["onset"])
+        onset = raw.time_as_index(annot["onset"]).astype(int)[0]
         duration = int(annot["duration"] * raw.info["sfreq"])
 
         # Triage type and description
@@ -128,7 +128,7 @@ def _mne_annots2pybv_events(raw):
             etype = "Comment"
 
         # Handle channels
-        channels = list(annot["channels"])
+        channels = list(annot["ch_names"])
 
         # Add a "pybv" event
         events += [

--- a/pybv/_export.py
+++ b/pybv/_export.py
@@ -1,11 +1,16 @@
 """Use pybv to export data from different software packages to BrainVision."""
 
 from pathlib import Path
+from warnings import warn
+
+import numpy as np
+from mne.channels.channels import _unit2human
+from mne.io.constants import FIFF
 
 from pybv import write_brainvision
 
 
-def _export_mne_raw(*, raw, fname, overwrite=False):
+def _export_mne_raw(*, raw, fname, events=None, overwrite=False):
     """Export raw data from MNE-Python.
 
     Parameters
@@ -16,14 +21,124 @@ def _export_mne_raw(*, raw, fname, overwrite=False):
         The name of the file where raw data will be exported to. Must end with ".vhdr",
         and accompanying ".vmrk" and ".eeg" files will be written inside the same
         directory.
-    overwrite: bool
-        Whether or not to overwrite existing data. Default to False
+    events : np.ndarray | None
+        Events to be written to the marker file (*.vmrk*). When array, must be in
+        `MNE-Python format <https://mne.tools/stable/glossary.html#term-events>`_.
+        When ``None`` (default), events will be written based on ``raw.annotations``.
+    overwrite : bool
+        Whether or not to overwrite existing data. Default to ``False``.
     """
-    data = raw.get_data()
-    sfreq = raw.info["sfreq"]
-    ch_names = raw.ch_names
+    # Prepare file location
     fname = Path(fname)
-    folder_out = fname.parents()[0]
+    folder_out = fname.parents[0]
     fname_base = fname.name
-    write_brainvision(data=data, sfreq=sfreq, ch_names=ch_names, fname_base=fname_base,
-                      folder_out=folder_out, overwrite=overwrite)
+
+    # Prepare data from raw
+    data = raw.get_data()  # gets data starting from raw.first_samp
+    sfreq = raw.info["sfreq"]  # in Hz
+    meas_date = raw.info["meas_date"]  # datetime.datetime
+    ch_names = raw.ch_names
+
+    # write voltage units as micro-volts and all other units without
+    # scaling
+    # We write units that we don't know as n/a
+    unit = []
+    for ch in raw.info["chs"]:
+        if ch["unit"] == FIFF.FIFF_UNIT_V:
+            unit.append("µV")
+        elif ch["unit"] == FIFF.FIFF_UNIT_CEL:
+            unit.append("°C")
+        else:
+            unit.append(_unit2human.get(ch["unit"], "n/a"))
+    unit = [u if u != "NA" else "n/a" for u in unit]
+
+    # We enforce conversion to float32 format
+    # XXX: Could add a feature that checks data and optimizes `unit`, `resolution`,
+    #      and `format` so that raw.orig_format could be retained if reasonable.
+    if raw.orig_format != "single":
+        warn(
+            f"Encountered data in '{raw.orig_format}' format. "
+            "Converting to float32.",
+            RuntimeWarning,
+        )
+
+    fmt = "binary_float32"
+    resolution = 0.1
+
+    # Handle events
+    # if we got an ndarray, this is in MNE-Python format
+    msg = "`events` must be None or array in MNE-Python format."
+    if events is not None:
+        # Subtract raw.first_samp because brainvision marks events starting from
+        # the first available data point and ignores the raw.first_samp
+        assert isinstance(events, np.ndarray), msg
+        assert events.ndim == 2, msg
+        assert events.shape[-1] == 3, msg
+        events[:, 0] -= raw.first_samp
+        events = events[:, [0, 2]]  # reorder for pybv required order
+
+    # else, prepare pybv style events from raw.annotations
+    else:
+        events = _mne_annots2pybv_events(raw)
+
+    # no information about reference channels in mne currently
+    ref_ch_names = None
+
+    # write to BrainVision
+    write_brainvision(
+        data=data,
+        sfreq=sfreq,
+        ch_names=ch_names,
+        ref_ch_names=ref_ch_names,
+        fname_base=fname_base,
+        folder_out=folder_out,
+        overwrite=overwrite,
+        events=events,
+        resolution=resolution,
+        unit=unit,
+        fmt=fmt,
+        meas_date=meas_date,
+    )
+
+
+def _mne_annots2pybv_events(raw):
+    """Convert mne Annotations to pybv events."""
+    events = []
+    for annot in raw.annotations:
+
+        # Handle onset and duration: seconds to sample,
+        # relative to raw.first_samp
+        onset = raw.time_as_index(annot["onset"])
+        duration = int(annot["duration"] * raw.info["sfreq"])
+
+        # Triage type and description
+        # Defaults to type="Comment", and the full description
+        etype = "Comment"
+        description = annot["description"]
+        for start in ["Stimulus/S", "Response/R", "Comment/"]:
+            if description.startswith(start):
+                etype = start.split("/")[0]
+                description = description.replace(start, "")
+                break
+
+        if etype in ["Stimulus", "Response"] and description.strip().isdigit():
+            description = int(description.strip())
+        else:
+            # if cannot convert to int, we must use this as "Comment"
+            etype = "Comment"
+
+        # Handle channels
+        channels = list(annot["channels"])
+
+        # Add a "pybv" event
+        events += [
+            dict(
+                onset=onset,
+                duration=duration,
+                description=description,
+                type=etype,
+                channels=channels,
+            )
+        ]
+
+    return events

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -539,7 +539,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events, meas_date):
     """Write BrainvVision marker file."""
     with open(vmrk_fname, 'w', encoding='utf-8') as fout:
         print('Brain Vision Data Exchange Marker File, Version 1.0', file=fout)
-        print(f';Exported using pybv {__version__}', file=fout)
+        print(f'; Exported using pybv {__version__}', file=fout)
         print('', file=fout)
         print('[Common Infos]', file=fout)
         print('Codepage=UTF-8', file=fout)

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -412,7 +412,7 @@ def _chk_events(events, ch_names, n_times):
         # validate key types
         # `onset`, `duration`
         for key in ["onset", "duration"]:
-            if not np.issubdtype(type(event[key]), np.int64):
+            if not isinstance(event[key], (int, np.integer)):
                 raise ValueError(f"events: `{key}` must be int")
 
         if not (0 <= event["onset"] < n_times):

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -412,7 +412,7 @@ def _chk_events(events, ch_names, n_times):
         # validate key types
         # `onset`, `duration`
         for key in ["onset", "duration"]:
-            if not isinstance(event[key], int):
+            if not np.issubdtype(type(event[key]), np.int64):
                 raise ValueError(f"events: `{key}` must be int")
 
         if not (0 <= event["onset"] < n_times):
@@ -508,6 +508,9 @@ def _chk_events(events, ch_names, n_times):
         # convert channels to indices (1-based, 0="all")
         ch_idxs = [ch_names.index(ch) + 1 for ch in event["channels"]]
         if set(ch_idxs) == {i + 1 for i in range(len(ch_names))}:
+            ch_idxs = [0]
+        elif len(ch_idxs) == 0:
+            # if not related to any channel: same as related to all channels
             ch_idxs = [0]
         event["channels"] = sorted(ch_idxs)
 

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -44,6 +44,7 @@ events = [
      },
     {"onset": 200,
      "description": 1234,
+     "channels": [],
      },
 ]
 # scale random data to reasonable EEG signal magnitude in V

--- a/pybv/tests/test_export.py
+++ b/pybv/tests/test_export.py
@@ -10,18 +10,32 @@ from pybv._export import _export_mne_raw
 def test_export_mne_raw(tmpdir):
     """Test mne export."""
     # Create a Raw object
-    sfreq = 250.
+    sfreq = 250.0
 
-    ch_names = ['Fp1', 'Fp2', 'Fz', 'Cz', 'Pz', 'O1', 'O2']
-    ch_types = ['eeg'] * len(ch_names)
+    ch_names = ["Fp1", "Fp2", "Fz", "Cz", "Pz", "O1", "O2"]
+    ch_types = ["eeg"] * len(ch_names)
 
     info = mne.create_info(ch_names, ch_types=ch_types, sfreq=sfreq)
 
-    info.set_montage('standard_1020')
+    info.set_montage("standard_1020")
 
     data = np.random.randn(len(ch_names), int(sfreq * 100))
 
     raw = mne.io.RawArray(data, info)
+
+    annots = mne.Annotations(
+        onset=[3, 13, 30, 70, 90],  # seconds
+        duration=[1, 1, 0.5, 0.25, 9],  # seconds
+        description=[
+            "Stimulus/S  1",
+            "Stimulus/S2.50",
+            "Response/R101",
+            "Look at this",
+            "Comment/And at this",
+        ],
+        ch_names=[(), (), (), ("Fp1",), ("Fp1", "Fp2")],
+    )
+    raw.set_annotations(annots)
 
     # export to BrainVision
     fname = tmpdir / "mne_export.vhdr"

--- a/pybv/tests/test_export.py
+++ b/pybv/tests/test_export.py
@@ -1,0 +1,29 @@
+"""Test export from software packages to BrainVision via pybv."""
+
+import mne
+import numpy as np
+import pytest
+
+from pybv._export import _export_mne_raw
+
+
+def test_export_mne_raw(tmpdir):
+    """Test mne export."""
+    # Create a Raw object
+    sfreq = 250.
+
+    ch_names = ['Fp1', 'Fp2', 'Fz', 'Cz', 'Pz', 'O1', 'O2']
+    ch_types = ['eeg'] * len(ch_names)
+
+    info = mne.create_info(ch_names, ch_types=ch_types, sfreq=sfreq)
+
+    info.set_montage('standard_1020')
+
+    data = np.random.randn(len(ch_names), int(sfreq * 100))
+
+    raw = mne.io.RawArray(data, info)
+
+    # export to BrainVision
+    fname = tmpdir / "mne_export.vhdr"
+    with pytest.warns(RuntimeWarning, match="'double' .* Converting to float32"):
+        _export_mne_raw(raw=raw, fname=fname)

--- a/pybv/tests/test_export.py
+++ b/pybv/tests/test_export.py
@@ -3,12 +3,12 @@
 import mne
 import numpy as np
 import pytest
-
 from mne.io.constants import FIFF
 
 from pybv._export import _export_mne_raw
 
 
+@pytest.mark.filterwarnings("ignore:.*non-voltage units.*n/a:UserWarning:pybv")
 def test_export_mne_raw(tmpdir):
     """Test mne export."""
     # Create a Raw object
@@ -46,6 +46,10 @@ def test_export_mne_raw(tmpdir):
     fname = tmpdir / "mne_export.vhdr"
     with pytest.warns(RuntimeWarning, match="'double' .* Converting to float32"):
         _export_mne_raw(raw=raw, fname=fname)
+
+    # test overwrite
+    with pytest.warns():
+        _export_mne_raw(raw=raw, fname=fname, overwrite=True)
 
     # try once more with "single" data and mne events
     fname = tmpdir / "mne_export_events.vhdr"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy>=1.18.1
-mne
+mne>=0.20
 check-manifest
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,11 @@ if __name__ == "__main__":
           install_requires=[
               'numpy >=1.18.1',
           ],
+          extras_require={
+              'export': [
+                  'mne >= 0.20',
+              ],
+          },
           classifiers=[
               'Intended Audience :: Science/Research',
               'Intended Audience :: Developers',


### PR DESCRIPTION
refs:

- https://github.com/mne-tools/mne-python/issues/10678
- https://github.com/mne-tools/mne-python/pull/10681
- https://github.com/mne-tools/mne-python/issues/10682


also includes a fix for when users would pass an empty list to `channels` in a list of dicts --> an empty list (no channel related to event) is now the same as "all channels related to event".
