### PR TITLE
FIX: annotations relative to raw.first_time

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,9 +30,9 @@ Here we list a changelog of pybv.
 0.8.0 (unreleased)
 ==================
 
-Changelog
-~~~~~~~~~
-- Nothing yet
+Bug
+~~~
+- Fixed that ``raw.annotations`` must take ``raw.first_time`` into account in private ``pybv._export`` module for export to BrainVision from MNE-Python, by `Stefan Appelhoff`_: (:gh:`91`)
 
 0.7.1 (2022-05-28)
 ==================

--- a/pybv/_export.py
+++ b/pybv/_export.py
@@ -109,8 +109,9 @@ def _mne_annots2pybv_events(raw):
     for annot in raw.annotations:
 
         # Handle onset and duration: seconds to sample,
-        # relative to raw.first_samp
-        onset = raw.time_as_index(annot["onset"]).astype(int)[0]
+        # relative to raw.first_samp / raw.first_time
+        onset = annot["onset"] - raw.first_time
+        onset = raw.time_as_index(onset).astype(int)[0]
         duration = int(annot["duration"] * raw.info["sfreq"])
 
         # Triage type and description


### PR DESCRIPTION
came up in https://github.com/mne-tools/mne-python/pull/10681