### PR TITLE
Do not distribute the specification PDF in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ recursive-exclude pybv/tests/__pycache__ *
 recursive-exclude docs/_build *
 recursive-exclude docs/generated *
 recursive-exclude .github *
+recursive-exclude specification *
 
 exclude .git-blame-ignore-revs
 exclude .pre-commit-config.yaml


### PR DESCRIPTION
Since the license terms under which the specification PDF are distributed are not clear, the contents of `specification/` pose a problem for some users and redistributors, such as Linux distribution packagers.

This PR would use `MANIFEST.in` to exclude it from PyPI sdists, although it would still be present in GitHub archives. Since the PyPI sdist does contain all the files needed to run tests and generate documentation, this could be a workable solution.

Alternative solutions would include:

- Document the license terms for the PDF, if known (see https://docs.fedoraproject.org/en-US/legal/allowed-licenses/)
- Remove the PDF from this repository; start a separate repository if you still want to track third-party documents in git