### PR TITLE
DRAFT: Add a Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+   install:
+   - method: pip
+     path: .
+     extra_requirements:
+       - export
+   - requirements: docs/requirements-rtd.txt


### PR DESCRIPTION
As requested in https://github.com/bids-standard/pybv/pull/105#issuecomment-1736995017, this attempts to fix the Read the Docs job by adding a configuration file (https://docs.readthedocs.io/en/stable/config-file/v2.html).