### PR TITLE
Fix pre-commit instructions in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,7 +38,7 @@ you can run tests by making use of the `Makefile` and
 From the project root, call:
 
 - `make test` to run tests and coverage
-- `pre-commit run` to run style checks (Ruff and some additional hooks)
+- `pre-commit run -a` to run style checks (Ruff and some additional hooks)
 
 ## Building the documentation
 


### PR DESCRIPTION
As mentioned by @hoechenberger, devs should run pre-commit on all files (not just staged files).