### PR TITLE
Support arbitrary markers

### DIFF
--- a/pybv/_export.py
+++ b/pybv/_export.py
@@ -117,18 +117,6 @@ def _mne_annots2pybv_events(raw):
         # defaults to type="Comment" and the full description
         etype = "Comment"
         description = annot["description"]
-        for start in ["Stimulus/S", "Response/R", "Comment/"]:
-            if description.startswith(start):
-                etype = start.split("/")[0]
-                description = description.replace(start, "")
-                break
-
-        if etype in ["Stimulus", "Response"] and description.strip().isdigit():
-            description = int(description.strip())
-        else:
-            # if cannot convert to int, we must use this as "Comment"
-            etype = "Comment"
-
         event_dict = dict(
             onset=onset,  # in samples
             duration=duration,  # in samples

--- a/pybv/io.py
+++ b/pybv/io.py
@@ -424,7 +424,7 @@ def _chk_events(events, ch_names, n_times):
 
         for event in events_out:
             if event["description"] < 0:
-                raise ValueError(f"events: descriptions must be non-negative ints.")
+                raise ValueError("events: descriptions must be non-negative ints.")
             tformat = event["type"][0] + "{:>" + str(twidth) + "}"
             event["description"] = tformat.format(event["description"])
 

--- a/pybv/tests/test_bv_writer.py
+++ b/pybv/tests/test_bv_writer.py
@@ -97,6 +97,7 @@ def test_non_stim_resp_event_first(tmpdir):
         (events_array, ""),
         (None, ""),
         (np.arange(90).reshape(30, 3), ""),
+        (np.array([[0, -1]]), "descriptions must be non-negative ints"),
     ],
 )
 def test_bv_writer_events_array(tmpdir, events_errormsg):


### PR DESCRIPTION
Fixes #103. This is a big (breaking) change, I decided to tackle this as follows:

- If the passed events is an `np.ndarray`, the previous conversion magic is still happening (i.e. `type` is set to `"Stimulus"` and integers are converted to `"S  1"` etc.).
- If the passed events is a list of dicts, markers are written as is.

This means that if someone needs to write "old-style" markers with custom types (such as `"Response"`, `"Comment"`, etc.), they must manually create a corresponding list of dicts.

I'm not sure if we need to change anything in MNE-Python, but I don't think so. It reads descriptions and types and combines them to "Type/Description", which I think should continue to work. The events from annotations heuristics will only work for "old-style" annotations, but that's OK I think.