### PR TITLE
Fix test for MNE-Python main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
   "build",
   "matplotlib",
   "mne",
+  "packaging",
   "pre-commit",
   "pytest",
   "pytest-cov",

--- a/tests/test_write_brainvision.py
+++ b/tests/test_write_brainvision.py
@@ -8,12 +8,12 @@ import os
 import re
 from datetime import datetime, timezone
 from importlib.metadata import version
-from packaging.version import Version
 
 import mne
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from packaging.version import Version
 
 from pybv.io import (
     SUPPORTED_FORMATS,
@@ -442,7 +442,7 @@ def test_write_read_cycle(tmpdir, meas_date, ref_ch_names):
     """Test that a write/read cycle produces identical data."""
     # First fail writing due to wrong unit
     unsupported_unit = "rV"
-    with pytest.warns(UserWarning, match="Encountered unsupported " "non-voltage unit"):
+    with pytest.warns(UserWarning, match="Encountered unsupported non-voltage unit"):
         write_brainvision(
             data=data,
             sfreq=sfreq,
@@ -653,7 +653,7 @@ def test_write_unsupported_units(tmpdir):
 
     # write brain vision file
     vhdr_fname = tmpdir / (fname + ".vhdr")
-    with pytest.warns(UserWarning, match="Encountered unsupported " "non-voltage unit"):
+    with pytest.warns(UserWarning, match="Encountered unsupported non-voltage unit"):
         write_brainvision(
             data=data,
             sfreq=sfreq,

--- a/tests/test_write_brainvision.py
+++ b/tests/test_write_brainvision.py
@@ -473,7 +473,7 @@ def test_write_read_cycle(tmpdir, meas_date, ref_ch_names):
     vhdr_fname = tmpdir / fname + ".vhdr"
     raw_written = mne.io.read_raw_brainvision(vhdr_fname=vhdr_fname, preload=True)
 
-    if Version(version("mne")) < Version("1.10"):
+    if Version(version("mne")).release < (1, 10):
         # delete the first annotation because it's just marking a new segment
         # (this is fixed in MNE-Python 1.10 or later)
         raw_written.annotations.delete(0)

--- a/tests/test_write_brainvision.py
+++ b/tests/test_write_brainvision.py
@@ -7,6 +7,8 @@ import itertools
 import os
 import re
 from datetime import datetime, timezone
+from importlib.metadata import version
+from packaging.version import Version
 
 import mne
 import numpy as np
@@ -470,8 +472,11 @@ def test_write_read_cycle(tmpdir, meas_date, ref_ch_names):
         )
     vhdr_fname = tmpdir / fname + ".vhdr"
     raw_written = mne.io.read_raw_brainvision(vhdr_fname=vhdr_fname, preload=True)
-    # delete the first annotation because it's just marking a new segment
-    raw_written.annotations.delete(0)
+
+    if Version(version("mne")) < Version("1.10"):
+        # delete the first annotation because it's just marking a new segment
+        # (this is fixed in MNE-Python 1.10 or later)
+        raw_written.annotations.delete(0)
     # convert our annotations to events
     events_written, event_id = mne.events_from_annotations(raw_written)
 


### PR DESCRIPTION
MNE-Python now discards the first "New Segment" annotation automatically, since it only contains the recording time (see https://github.com/mne-tools/mne-python/pull/13100).