### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13"]
+        python-version: ["3.14"]
     env:
       TZ: Europe/Berlin
       FORCE_COLOR: true

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -19,14 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
         mne-version: [mne-stable]
 
         include:
           # special test runs running only on single CI systems to save resources
           # Test development versions
           - platform: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.14"
             mne-version: mne-main
 
     runs-on: ${{ matrix.platform }}
@@ -83,7 +83,7 @@ jobs:
         make -C docs/ html
 
     - name: Upload artifacts
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.mne-version == 'mne-stable'}}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.14' && matrix.mne-version == 'mne-stable'}}
       uses: actions/upload-artifact@v7
       with:
         name: docs-artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.13"
+    python: "3.14"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,7 @@ Here we list a changelog of pybv.
 Code health
 ~~~~~~~~~~~
 - Add support for Python 3.13 and drop support for Python 3.9, by `Clemens Brunner`_ (:gh:`128`)
+- Add support for Python 3.14, by `Stefan Appelhoff`_ (:gh:`145`)
 
 0.7.6 (2024-11-25)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python",
   "Topic :: Scientific/Engineering",
 ]


### PR DESCRIPTION
## Summary

Enables Python 3.14 support.

- Adds the `Programming Language :: Python :: 3.14` trove classifier in `pyproject.toml` (`requires-python` stays `>=3.10`; 3.13 classifier kept).
- Tests on Python 3.14 in CI. Following the existing convention of testing only the oldest and newest supported versions, the `python_tests.yml` matrix becomes `["3.10", "3.14"]`.
- Bumps the single pinned "latest" Python from 3.13 to 3.14 for the jobs that use one: the `mne-main` development run, the docs/coverage artifact upload condition, the `python_build.yml` build job, and the `release.yml` release job.
- Adds a changelog entry under `0.8.0 (unreleased)`.
